### PR TITLE
feat: persist active video across reload + clickable coach timestamps

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { ChatMessage, Sport } from "@/types/playlog";
 import { Send } from "lucide-react";
+import { FeedbackText } from "@/lib/timestamps";
 
 interface ChatInterfaceProps {
   messages: ChatMessage[];
@@ -8,9 +9,12 @@ interface ChatInterfaceProps {
   sport: Sport;
   disabled?: boolean;
   presetPrompts?: string[];
+  /** When provided, timestamp tokens (m:ss) inside assistant replies become
+   *  buttons that seek the active video. */
+  onSeek?: (seconds: number) => void;
 }
 
-export function ChatInterface({ messages, onSend, sport: _sport, disabled = false, presetPrompts = [] }: ChatInterfaceProps) {
+export function ChatInterface({ messages, onSend, sport: _sport, disabled = false, presetPrompts = [], onSeek }: ChatInterfaceProps) {
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -69,7 +73,11 @@ export function ChatInterface({ messages, onSend, sport: _sport, disabled = fals
                 {msg.role === "assistant" && (
                   <p className="text-[10px] font-semibold text-primary uppercase tracking-wide mb-1">Coach</p>
                 )}
-                <div className="whitespace-pre-wrap">{msg.content}</div>
+                <div className="whitespace-pre-wrap">
+                  {msg.role === "assistant"
+                    ? <FeedbackText text={msg.content} onSeek={onSeek} />
+                    : msg.content}
+                </div>
               </div>
               {msg.role === "user" && (
                 <div className="flex-shrink-0 w-7 h-7 rounded-full bg-foreground border border-border flex items-center justify-center text-sm">

--- a/frontend/src/components/SessionLibrary.tsx
+++ b/frontend/src/components/SessionLibrary.tsx
@@ -1,50 +1,11 @@
 import { useState } from "react";
 import { Session, getRatingTier, ratingBarColor } from "@/types/playlog";
 import { ChevronDown } from "lucide-react";
+import { FeedbackText } from "@/lib/timestamps";
 
 interface SessionLibraryProps {
   sessions: Session[];
   onSeek?: (seconds: number) => void;
-}
-
-/** Parse "m:ss" or "h:mm:ss" timestamps from a string, return array of {label, seconds} */
-function extractTimestamps(text: string): Array<{ label: string; seconds: number }> {
-  const matches = [...text.matchAll(/\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/g)];
-  return matches.map((m) => {
-    const hasHours = m[3] !== undefined;
-    const hours   = hasHours ? parseInt(m[1]) : 0;
-    const minutes = hasHours ? parseInt(m[2]) : parseInt(m[1]);
-    const secs    = hasHours ? parseInt(m[3]) : parseInt(m[2]);
-    return { label: m[0], seconds: hours * 3600 + minutes * 60 + secs };
-  });
-}
-
-/** Render a feedback string with inline timestamp chips that call onSeek */
-function FeedbackText({ text, onSeek }: { text: string; onSeek?: (s: number) => void }) {
-  if (!onSeek) return <span>{text}</span>;
-
-  const timestamps = extractTimestamps(text);
-  if (timestamps.length === 0) return <span>{text}</span>;
-
-  const parts: React.ReactNode[] = [];
-  let cursor = 0;
-  for (const ts of timestamps) {
-    const idx = text.indexOf(ts.label, cursor);
-    if (idx > cursor) parts.push(text.slice(cursor, idx));
-    parts.push(
-      <button
-        key={idx}
-        onClick={() => onSeek(ts.seconds)}
-        className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono bg-primary/10 text-primary hover:bg-primary/20 transition-colors mx-0.5"
-      >
-        {ts.label}
-      </button>
-    );
-    cursor = idx + ts.label.length;
-  }
-  if (cursor < text.length) parts.push(text.slice(cursor));
-
-  return <span>{parts}</span>;
 }
 
 export function SessionLibrary({ sessions, onSeek }: SessionLibraryProps) {

--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -7,26 +7,35 @@ export interface VideoPlayerHandle {
 }
 
 interface VideoPlayerProps {
-  file: File;
+  /** Local file (immediately after upload). One of file/src is required. */
+  file?: File;
+  /** Remote URL (e.g. R2 presigned read URL) — used after a reload when the
+   *  original File object is no longer in memory. */
+  src?: string;
   /** Optional list of cue points to mark on the progress bar (in seconds) */
   cues?: number[];
 }
 
 export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
-  ({ file, cues = [] }, ref) => {
+  ({ file, src, cues = [] }, ref) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const [playing, setPlaying] = useState(false);
     const [currentTime, setCurrentTime] = useState(0);
     const [duration, setDuration] = useState(0);
-    const objectUrl = useRef<string | null>(null);
 
-    // Create object URL once per file
+    // Two source modes: local File (createObjectURL + revoke), or a plain URL
+    // string (just set src directly). The else-branch lets the player rehydrate
+    // a session's R2 video after the user reloads the page or navigates back.
     useEffect(() => {
-      const url = URL.createObjectURL(file);
-      objectUrl.current = url;
-      if (videoRef.current) videoRef.current.src = url;
-      return () => URL.revokeObjectURL(url);
-    }, [file]);
+      if (file) {
+        const url = URL.createObjectURL(file);
+        if (videoRef.current) videoRef.current.src = url;
+        return () => URL.revokeObjectURL(url);
+      }
+      if (src && videoRef.current) {
+        videoRef.current.src = src;
+      }
+    }, [file, src]);
 
     useImperativeHandle(ref, () => ({
       seekTo(seconds: number) {

--- a/frontend/src/components/tabs/Learn.tsx
+++ b/frontend/src/components/tabs/Learn.tsx
@@ -29,6 +29,14 @@ export function Learn({ sport, userId }: LearnProps) {
   const effectiveSessionId: Id<"sessions"> | null =
     sessionId ?? rawSessions?.[0]?.session._id ?? null;
 
+  // Rehydrate the video from R2 when we don't have the original File in
+  // memory — covers tab switches and full reloads. The local File takes
+  // precedence (cheaper, no presign round-trip) when it's present.
+  const persistedVideoUrl = useQuery(
+    api.storage.getSessionVideoUrl,
+    !currentVideo && effectiveSessionId ? { sessionId: effectiveSessionId } : "skip"
+  );
+
   // Extract MediaPipe cue timestamps (in seconds) from the most-recent analysis
   const latestPoseAnalysis = rawSessions?.find((s) => s.session._id === effectiveSessionId)?.poseAnalysis ?? null;
   const cues: number[] = (() => {
@@ -99,14 +107,25 @@ export function Learn({ sport, userId }: LearnProps) {
   const isDone = status === "ready";
   const isError = status === "error";
 
+  // Either we have the freshly-uploaded File, or we have a persisted session
+  // whose video lives in R2 — show the player in either case so the user can
+  // keep referencing it across navigation and reloads.
+  const hasPlayableVideo = !!currentVideo || !!persistedVideoUrl;
+  const showSwitchButton =
+    hasPlayableVideo && (isDone || isError || (!currentVideo && !!persistedVideoUrl));
+
   return (
     <div className="space-y-6">
-      {/* Video player — shown once a file is selected */}
-      {currentVideo ? (
+      {/* Video player — shown when a file is selected OR a session is persisted */}
+      {hasPlayableVideo ? (
         <div className="space-y-2">
-          <VideoPlayer ref={videoPlayerRef} file={currentVideo} cues={cues} />
-          {/* Re-upload button once done or errored */}
-          {(isDone || isError) && (
+          <VideoPlayer
+            ref={videoPlayerRef}
+            file={currentVideo ?? undefined}
+            src={!currentVideo ? persistedVideoUrl ?? undefined : undefined}
+            cues={cues}
+          />
+          {showSwitchButton && (
             <button
               onClick={reset}
               className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors"
@@ -136,6 +155,7 @@ export function Learn({ sport, userId }: LearnProps) {
         sport={sport}
         disabled={!effectiveSessionId}
         presetPrompts={presetPrompts}
+        onSeek={handleSeek}
       />
     </div>
   );

--- a/frontend/src/hooks/useVideoAnalysis.ts
+++ b/frontend/src/hooks/useVideoAnalysis.ts
@@ -46,6 +46,11 @@ interface UseVideoAnalysisResult {
   reset: () => void;
 }
 
+// Stored under a per-user key so multiple profiles on the same browser don't
+// step on each other's "active" video. We only persist the session ID — the
+// video URL is rehydrated on demand from R2 via api.storage.getSessionVideoUrl.
+const ACTIVE_SESSION_KEY = (userId: string) => `playlog.activeSession.${userId}`;
+
 export function useVideoAnalysis({
   userId,
   sport,
@@ -53,10 +58,25 @@ export function useVideoAnalysis({
 }: UseVideoAnalysisParams): UseVideoAnalysisResult {
   const [status, setStatus] = useState<AnalysisStatus>("idle");
   const [error, setError] = useState<string | null>(null);
-  const [sessionId, setSessionId] = useState<Id<"sessions"> | null>(null);
+  const [sessionId, setSessionIdState] = useState<Id<"sessions"> | null>(() => {
+    if (typeof window === "undefined") return null;
+    return (window.localStorage.getItem(ACTIVE_SESSION_KEY(userId)) as Id<"sessions"> | null) ?? null;
+  });
   const [feedbackId, setFeedbackId] = useState<string | null>(null);
   const [currentVideo, setCurrentVideo] = useState<File | null>(null);
   const abortRef = useRef(false);
+
+  // Mirror state writes through to localStorage so a reload (or a tab switch
+  // that unmounts Learn) can rehydrate the active session.
+  const setSessionId = useCallback(
+    (id: Id<"sessions"> | null) => {
+      setSessionIdState(id);
+      if (typeof window === "undefined") return;
+      if (id) window.localStorage.setItem(ACTIVE_SESSION_KEY(userId), id);
+      else window.localStorage.removeItem(ACTIVE_SESSION_KEY(userId));
+    },
+    [userId]
+  );
 
   const reset = useCallback(() => {
     abortRef.current = true;
@@ -65,7 +85,7 @@ export function useVideoAnalysis({
     setSessionId(null);
     setFeedbackId(null);
     setCurrentVideo(null);
-  }, []);
+  }, [setSessionId]);
 
   const generateUploadUrl = useMutation(api.storage.generateUploadUrl);
   const createSession = useMutation(api.sessions.createSession);

--- a/frontend/src/lib/timestamps.tsx
+++ b/frontend/src/lib/timestamps.tsx
@@ -1,0 +1,50 @@
+import type React from "react";
+
+// Parse "m:ss" or "h:mm:ss" timestamps from a string. Used by the session
+// detail and chat panes so coach-generated timestamps render as inline
+// seek-buttons that jump the active video.
+export function extractTimestamps(text: string): Array<{ label: string; seconds: number }> {
+  const matches = [...text.matchAll(/\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/g)];
+  return matches.map((m) => {
+    const hasHours = m[3] !== undefined;
+    const hours   = hasHours ? parseInt(m[1]!) : 0;
+    const minutes = hasHours ? parseInt(m[2]!) : parseInt(m[1]!);
+    const secs    = hasHours ? parseInt(m[3]!) : parseInt(m[2]!);
+    return { label: m[0], seconds: hours * 3600 + minutes * 60 + secs };
+  });
+}
+
+interface FeedbackTextProps {
+  text: string;
+  onSeek?: (seconds: number) => void;
+}
+
+// Render a string with inline timestamp chips that call onSeek. If no onSeek
+// is provided (or no timestamps are present) it degrades to a plain span.
+export function FeedbackText({ text, onSeek }: FeedbackTextProps) {
+  if (!onSeek) return <span>{text}</span>;
+
+  const timestamps = extractTimestamps(text);
+  if (timestamps.length === 0) return <span>{text}</span>;
+
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  for (const ts of timestamps) {
+    const idx = text.indexOf(ts.label, cursor);
+    if (idx > cursor) parts.push(text.slice(cursor, idx));
+    parts.push(
+      <button
+        key={idx}
+        type="button"
+        onClick={() => onSeek(ts.seconds)}
+        className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono bg-primary/10 text-primary hover:bg-primary/20 transition-colors mx-0.5"
+      >
+        {ts.label}
+      </button>
+    );
+    cursor = idx + ts.label.length;
+  }
+  if (cursor < text.length) parts.push(text.slice(cursor));
+
+  return <span>{parts}</span>;
+}


### PR DESCRIPTION
## Summary
- Active session is mirrored to localStorage; reloads and tab switches no longer lose the analyzed video
- VideoPlayer accepts either a local File (fresh upload) or a remote URL (rehydrated from R2 via presigned URL)
- Coach replies now render with clickable \`m:ss\` timestamps that seek the active video, same UX as the session detail panel

## Test plan
- [ ] Upload a video → wait for analysis → switch to Progress tab → switch back → video still there, coach still works
- [ ] Upload a video → analyze → reload the page → video re-renders from R2, AI coach can still answer questions referencing it
- [ ] Click a \`m:ss\` token in a coach reply → video seeks to that moment
- [ ] Click "Upload a different video" → resets to upload area, localStorage entry removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)