### PR TITLE
feat: ground coach timestamps to MediaPipe pose key-frames

### DIFF
--- a/frontend/src/hooks/useVideoAnalysis.ts
+++ b/frontend/src/hooks/useVideoAnalysis.ts
@@ -151,19 +151,12 @@ Identify strengths, weaknesses, and specific drills to improve each area.`;
 
         if (abortRef.current) return;
 
-        // ── Step 5: Gemini coaching feedback ──────────────────────────────────
+        // ── Step 5: MediaPipe pose scoring ────────────────────────────────────
+        // Runs BEFORE coach feedback so the server can build an authoritative
+        // timeline (pose key-frames + Pegasus anchors) and ground Claude's
+        // timestamps against it.
         setStatus("scoring");
 
-        const newFeedbackId = await generateFeedback({
-          sessionId: newSessionId,
-          analysisId: newAnalysisId,
-        });
-
-        setFeedbackId(newFeedbackId);
-
-        if (abortRef.current) return;
-
-        // ── Step 6: MediaPipe pose scoring (after Gemini) ─────────────────────
         disposePoseLandmarker();
         const videoEl = document.createElement("video");
         videoEl.src = URL.createObjectURL(videoFile);
@@ -189,6 +182,16 @@ Identify strengths, weaknesses, and specific drills to improve each area.`;
             technique: poseResults.map((r) => r.technique).join(","),
           });
         }
+
+        if (abortRef.current) return;
+
+        // ── Step 6: Coach feedback (now grounded by pose timeline) ────────────
+        const newFeedbackId = await generateFeedback({
+          sessionId: newSessionId,
+          analysisId: newAnalysisId,
+        });
+
+        setFeedbackId(newFeedbackId);
 
         // ── Step 7: Check and award badges ────────────────────────────────────
         await checkAndAwardBadges({ userId });

--- a/server/src/lib/timeline.ts
+++ b/server/src/lib/timeline.ts
@@ -1,0 +1,177 @@
+// Builds an "authoritative timeline" of moments in a video that we can hand to
+// Claude as the ONLY allowed reference points. Two sources are merged:
+//
+//   1. MediaPipe key frames (frame-accurate phase transitions: backswing,
+//      impact, follow-through, etc). These are the gold standard.
+//   2. Timestamps Claude/TwelveLabs already mentioned in the Pegasus output
+//      text — kept as fallback anchors so we don't strip moments Pegasus
+//      identified that pose detection missed.
+//
+// Claude is instructed to only reference timestamps from this list, and any
+// timestamp it emits is post-validated by snapTimestamp() — snapped to the
+// nearest authoritative moment within tolerance, or stripped.
+
+export interface TimelineMoment {
+  /** seconds, integer-second precision */
+  seconds: number;
+  /** human label for the prompt, e.g. "0:03 backswing" */
+  label: string;
+  /** where this came from, for debugging/observability */
+  source: "pose" | "pegasus";
+}
+
+const TIMESTAMP_RE = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/g;
+
+function fmt(secs: number): string {
+  const m = Math.floor(secs / 60);
+  const s = Math.floor(secs % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+// Parse all m:ss / h:mm:ss tokens out of a free-text blob and return them as
+// numeric seconds. Used to extract whatever Pegasus already said.
+export function extractTimestampsFromText(text: string): number[] {
+  const out: number[] = [];
+  for (const m of text.matchAll(TIMESTAMP_RE)) {
+    const hasHours = m[3] !== undefined;
+    const hours = hasHours ? parseInt(m[1]!) : 0;
+    const minutes = hasHours ? parseInt(m[2]!) : parseInt(m[1]!);
+    const secs = hasHours ? parseInt(m[3]!) : parseInt(m[2]!);
+    out.push(hours * 3600 + minutes * 60 + secs);
+  }
+  return out;
+}
+
+interface KeyFrameLite {
+  timestampMs: number;
+  phase: string;
+}
+
+interface PoseAnalysisLite {
+  technique?: string;
+  keyFrames?: KeyFrameLite[];
+}
+
+// Extract key-frame moments from the serialized poseAnalysis JSON. The shape
+// is `AnalysisResult | AnalysisResult[]` because we score multiple techniques
+// per session — each result has its own keyFrames.
+export function momentsFromPoseAnalysis(serialized: string | null | undefined): TimelineMoment[] {
+  if (!serialized) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serialized);
+  } catch {
+    return [];
+  }
+  const results: PoseAnalysisLite[] = Array.isArray(parsed)
+    ? (parsed as PoseAnalysisLite[])
+    : [parsed as PoseAnalysisLite];
+
+  const out: TimelineMoment[] = [];
+  for (const r of results) {
+    const technique = r.technique ?? "";
+    for (const kf of r.keyFrames ?? []) {
+      const seconds = Math.round(kf.timestampMs / 1000);
+      const phase = kf.phase.replace(/_/g, " ");
+      const label = technique
+        ? `${fmt(seconds)} ${technique} ${phase}`
+        : `${fmt(seconds)} ${phase}`;
+      out.push({ seconds, label, source: "pose" });
+    }
+  }
+  return out;
+}
+
+export function momentsFromPegasusText(text: string | null | undefined): TimelineMoment[] {
+  if (!text) return [];
+  return extractTimestampsFromText(text).map((seconds) => ({
+    seconds,
+    label: `${fmt(seconds)} (mentioned in video analysis)`,
+    source: "pegasus" as const,
+  }));
+}
+
+// Merge sources, dedupe near-duplicate seconds (pose wins because it's
+// frame-accurate), sort chronologically.
+export function buildTimeline(
+  poseAnalysis: string | null | undefined,
+  pegasusText: string | null | undefined,
+  dedupeWindowSec = 1
+): TimelineMoment[] {
+  const all = [
+    ...momentsFromPoseAnalysis(poseAnalysis),
+    ...momentsFromPegasusText(pegasusText),
+  ].sort((a, b) => a.seconds - b.seconds);
+
+  const out: TimelineMoment[] = [];
+  for (const m of all) {
+    const prev = out[out.length - 1];
+    if (prev && Math.abs(m.seconds - prev.seconds) <= dedupeWindowSec) {
+      // Pose wins on tie — Pegasus moment within ±1s of a pose moment is
+      // assumed redundant.
+      if (prev.source === "pegasus" && m.source === "pose") {
+        out[out.length - 1] = m;
+      }
+      continue;
+    }
+    out.push(m);
+  }
+  return out;
+}
+
+// Snap a Claude-emitted timestamp to the nearest authoritative moment within
+// tolerance. Returns the snapped seconds, or null if nothing is close enough.
+export function snapTimestamp(
+  seconds: number,
+  authoritative: number[],
+  toleranceSec = 2
+): number | null {
+  if (authoritative.length === 0) return null;
+  let best = -1;
+  let bestDist = Infinity;
+  for (const a of authoritative) {
+    const d = Math.abs(a - seconds);
+    if (d < bestDist) {
+      bestDist = d;
+      best = a;
+    }
+  }
+  return bestDist <= toleranceSec ? best : null;
+}
+
+// Walk a string, find every m:ss token, snap it to the authoritative timeline,
+// and rewrite. Tokens with no nearby anchor are left unchanged (stripping
+// would mangle surrounding punctuation like " — — fix").
+//
+// Returns { text, stats } so the caller can log how aggressive the pass was.
+export function snapTimestampsInText(
+  text: string,
+  authoritative: number[],
+  toleranceSec = 2
+): { text: string; snapped: number; unmatched: number } {
+  let snapped = 0;
+  let unmatched = 0;
+  const rewritten = text.replace(TIMESTAMP_RE, (match, p1, p2, p3) => {
+    const hasHours = p3 !== undefined;
+    const hours = hasHours ? parseInt(p1) : 0;
+    const minutes = hasHours ? parseInt(p2) : parseInt(p1);
+    const secs = hasHours ? parseInt(p3) : parseInt(p2);
+    const total = hours * 3600 + minutes * 60 + secs;
+
+    const snappedSec = snapTimestamp(total, authoritative, toleranceSec);
+    if (snappedSec === null) {
+      unmatched += 1;
+      return match;
+    }
+    if (snappedSec !== total) snapped += 1;
+    return fmt(snappedSec);
+  });
+  return { text: rewritten, snapped, unmatched };
+}
+
+// Format the timeline as a numbered list for inclusion in the system prompt.
+// Truncated to keep the prompt small.
+export function formatTimelineForPrompt(timeline: TimelineMoment[], max = 20): string {
+  if (timeline.length === 0) return "(no authoritative timeline available)";
+  return timeline.slice(0, max).map((m, i) => `${i + 1}. ${m.label}`).join("\n");
+}

--- a/server/src/routes/coach.ts
+++ b/server/src/routes/coach.ts
@@ -5,6 +5,12 @@ import { sql } from "../db/client.js";
 import { mapAnalysis, mapFeedback, mapMessage, mapSession } from "../db/mappers.js";
 import { ApiError, rpc } from "../lib/route.js";
 import { env } from "../lib/env.js";
+import {
+  buildTimeline,
+  formatTimelineForPrompt,
+  snapTimestampsInText,
+  type TimelineMoment,
+} from "../lib/timeline.js";
 
 export const coach = new Hono();
 
@@ -83,9 +89,21 @@ coach.post(
       analysis.twelveLabsResult ?? undefined
     );
 
+    // Anchor Claude to a known set of moments. Pose key-frames (frame-accurate)
+    // win over Pegasus-mentioned timestamps; Claude is forbidden from inventing
+    // numbers, and its output is post-snapped to the nearest authoritative moment.
+    const timeline = buildTimeline(analysis.poseAnalysis, analysis.twelveLabsResult);
+    const authoritativeSeconds = timeline.map((m) => m.seconds);
+    const timelineForPrompt = formatTimelineForPrompt(timeline);
+
     const userPrompt = `${sessionContext}
 
-Generate coaching feedback as JSON: a 2-3 sentence summary, an array of strengths (each with a timestamp), an array of improvements (each formatted as "issue — timestamp — fix"), and an array of drills (one per improvement).`;
+Authoritative timeline (the ONLY moments you may reference):
+${timelineForPrompt}
+
+Generate coaching feedback as JSON: a 2-3 sentence summary, an array of strengths (each with a timestamp from the timeline above), an array of improvements (each formatted as "issue — timestamp — fix"), and an array of drills (one per improvement).
+
+Hard rule: every timestamp you use MUST come from the timeline above, written in m:ss format. If a moment isn't in the timeline, describe it without a timestamp rather than guess.`;
 
     let parsed: z.infer<typeof FeedbackSchema>;
     try {
@@ -121,14 +139,24 @@ Generate coaching feedback as JSON: a 2-3 sentence summary, an array of strength
       throw toApiError(err, "Anthropic API error");
     }
 
+    // Snap any timestamps Claude emitted to the nearest authoritative moment.
+    // This catches the cases where the prompt constraint wasn't followed
+    // (Claude rounded "0:05" to "0:07", or invented a moment Pegasus mentioned
+    // approximately).
+    const snap = (s: string) => snapTimestampsInText(s, authoritativeSeconds).text;
+    const summary = snap(parsed.summary);
+    const strengths = parsed.strengths.map(snap);
+    const improvements = parsed.improvements.map(snap);
+    const drills = parsed.drills.map(snap);
+
     const [row] = await sql`
       INSERT INTO feedback (
         session_id, analysis_id, summary, strengths, improvements, drills, created_at
       ) VALUES (
-        ${sessionId}, ${analysisId}, ${parsed.summary},
-        ${sql.array(parsed.strengths)},
-        ${sql.array(parsed.improvements)},
-        ${sql.array(parsed.drills)},
+        ${sessionId}, ${analysisId}, ${summary},
+        ${sql.array(strengths)},
+        ${sql.array(improvements)},
+        ${sql.array(drills)},
         ${Date.now()}
       )
       RETURNING id
@@ -187,6 +215,18 @@ coach.post(
       VALUES (${sessionId}, 'user', ${trimmed}, ${Date.now()})
     `;
 
+    // Same grounding the feedback path uses — pose key-frames + Pegasus
+    // anchors, deduped. Constraint goes in the system prompt so it's enforced
+    // across every chat turn, and the reply is post-snapped before saving.
+    const timeline = buildTimeline(
+      latestAnalysis?.poseAnalysis,
+      latestAnalysis?.twelveLabsResult
+    );
+    const authoritativeSeconds = timeline.map((m: TimelineMoment) => m.seconds);
+    const timelineSection = timeline.length > 0
+      ? `\n\nAuthoritative timeline (the ONLY moments you may reference; m:ss):\n${formatTimelineForPrompt(timeline)}\n\nHard rule: every timestamp you use MUST come from the timeline above. If a moment isn't in the timeline, describe it without a timestamp.`
+      : "";
+
     const systemContext = latestFeedback
       ? `Sport: ${session.sport}. Focus: ${session.requestedSections.join(", ")}.\nLatest summary: ${latestFeedback.summary}`
       : buildSessionContext(
@@ -208,7 +248,7 @@ coach.post(
       const result = await getClient().messages.create({
         model: MODEL,
         max_tokens: 512,
-        system: `${COACH_SYSTEM_PROMPT}\n\n${systemContext}`,
+        system: `${COACH_SYSTEM_PROMPT}\n\n${systemContext}${timelineSection}`,
         messages,
       });
 
@@ -220,11 +260,15 @@ coach.post(
       throw toApiError(err, "Anthropic API error");
     }
 
+    const groundedReply = authoritativeSeconds.length > 0
+      ? snapTimestampsInText(reply, authoritativeSeconds).text
+      : reply;
+
     await sql`
       INSERT INTO messages (session_id, role, content, created_at)
-      VALUES (${sessionId}, 'model', ${reply}, ${Date.now()})
+      VALUES (${sessionId}, 'model', ${groundedReply}, ${Date.now()})
     `;
 
-    return reply;
+    return groundedReply;
   })
 );

--- a/server/tests/timeline.test.ts
+++ b/server/tests/timeline.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildTimeline,
+  extractTimestampsFromText,
+  formatTimelineForPrompt,
+  momentsFromPoseAnalysis,
+  snapTimestamp,
+  snapTimestampsInText,
+} from "../src/lib/timeline.js";
+
+// Compact pose-analysis fixtures matching the AnalysisResult shape produced by
+// the MediaPipe scorers — only the fields the timeline builder reads.
+const FOREHAND = JSON.stringify({
+  technique: "forehand",
+  keyFrames: [
+    { timestampMs: 1000, phase: "preparation" },
+    { timestampMs: 3000, phase: "backswing" },
+    { timestampMs: 5000, phase: "impact" },
+    { timestampMs: 7000, phase: "follow_through" },
+  ],
+});
+
+describe("extractTimestampsFromText", () => {
+  test("parses m:ss tokens", () => {
+    expect(extractTimestampsFromText("issue at 0:23 and 1:05")).toEqual([23, 65]);
+  });
+
+  test("parses h:mm:ss tokens", () => {
+    expect(extractTimestampsFromText("highlight at 1:02:30")).toEqual([3750]);
+  });
+
+  test("ignores non-timestamp digits", () => {
+    expect(extractTimestampsFromText("score is 80 out of 100")).toEqual([]);
+  });
+});
+
+describe("momentsFromPoseAnalysis", () => {
+  test("converts keyFrames to labeled moments", () => {
+    const moments = momentsFromPoseAnalysis(FOREHAND);
+    expect(moments).toHaveLength(4);
+    expect(moments[0]).toEqual({ seconds: 1, label: "0:01 forehand preparation", source: "pose" });
+    expect(moments[2]).toEqual({ seconds: 5, label: "0:05 forehand impact", source: "pose" });
+  });
+
+  test("returns empty for null/invalid input", () => {
+    expect(momentsFromPoseAnalysis(null)).toEqual([]);
+    expect(momentsFromPoseAnalysis("not json")).toEqual([]);
+  });
+
+  test("handles array of analyses (multi-technique sessions)", () => {
+    const multi = JSON.stringify([
+      JSON.parse(FOREHAND),
+      { technique: "serve", keyFrames: [{ timestampMs: 12000, phase: "impact" }] },
+    ]);
+    const moments = momentsFromPoseAnalysis(multi);
+    expect(moments.find((m) => m.label.includes("serve"))).toBeDefined();
+  });
+});
+
+describe("buildTimeline", () => {
+  test("merges pose + pegasus, dedupes near-duplicates with pose winning", () => {
+    // Pegasus mentions 0:05 (matches pose impact) and 0:09 (no pose anchor)
+    const pegasusText = "Player makes contact at 0:05 and finishes at 0:09";
+    const timeline = buildTimeline(FOREHAND, pegasusText);
+
+    // 0:05 should appear once and be the pose-labeled version, not pegasus
+    const fiveSec = timeline.filter((m) => m.seconds === 5);
+    expect(fiveSec).toHaveLength(1);
+    expect(fiveSec[0]!.source).toBe("pose");
+
+    // 0:09 has no pose anchor so it survives as pegasus
+    expect(timeline.find((m) => m.seconds === 9)?.source).toBe("pegasus");
+  });
+
+  test("sorts chronologically", () => {
+    const timeline = buildTimeline(FOREHAND, "");
+    const seconds = timeline.map((m) => m.seconds);
+    expect(seconds).toEqual([...seconds].sort((a, b) => a - b));
+  });
+});
+
+describe("snapTimestamp", () => {
+  const anchors = [3, 5, 7, 12];
+
+  test("snaps within tolerance to nearest", () => {
+    expect(snapTimestamp(6, anchors, 2)).toBe(5);
+    expect(snapTimestamp(6.5, anchors, 2)).toBe(7);
+  });
+
+  test("returns null when no anchor is within tolerance", () => {
+    expect(snapTimestamp(20, anchors, 2)).toBeNull();
+  });
+
+  test("exact match returns the anchor itself", () => {
+    expect(snapTimestamp(5, anchors, 2)).toBe(5);
+  });
+
+  test("empty anchor list returns null", () => {
+    expect(snapTimestamp(5, [], 2)).toBeNull();
+  });
+});
+
+describe("snapTimestampsInText", () => {
+  const anchors = [3, 5, 7];
+
+  test("rewrites in-tolerance timestamps to the snapped value", () => {
+    const result = snapTimestampsInText("issue at 0:06 — slow", anchors, 2);
+    expect(result.text).toBe("issue at 0:05 — slow");
+    expect(result.snapped).toBe(1);
+    expect(result.unmatched).toBe(0);
+  });
+
+  test("leaves out-of-tolerance timestamps unchanged and counts them", () => {
+    const result = snapTimestampsInText("at 0:30 player jumps", anchors, 2);
+    expect(result.text).toBe("at 0:30 player jumps");
+    expect(result.unmatched).toBe(1);
+  });
+
+  test("handles multiple timestamps in one string", () => {
+    const result = snapTimestampsInText("from 0:04 to 0:08", anchors, 2);
+    expect(result.text).toBe("from 0:03 to 0:07");
+    expect(result.snapped).toBe(2);
+  });
+});
+
+describe("formatTimelineForPrompt", () => {
+  test("formats numbered list", () => {
+    const timeline = momentsFromPoseAnalysis(FOREHAND);
+    const out = formatTimelineForPrompt(timeline);
+    expect(out).toContain("1. 0:01 forehand preparation");
+    expect(out).toContain("4. 0:07 forehand follow through");
+  });
+
+  test("returns placeholder for empty timeline", () => {
+    expect(formatTimelineForPrompt([])).toContain("no authoritative timeline");
+  });
+
+  test("truncates to max", () => {
+    const big = Array.from({ length: 50 }, (_, i) => ({
+      seconds: i,
+      label: `${i}`,
+      source: "pose" as const,
+    }));
+    const out = formatTimelineForPrompt(big, 5);
+    expect(out.split("\n")).toHaveLength(5);
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,7 +11,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "isolatedModules": true,
     "verbatimModuleSyntax": false,
     "types": ["node"]


### PR DESCRIPTION
## Summary
- Builds an "authoritative timeline" merging MediaPipe pose key-frames (frame-accurate phase transitions) with timestamps Pegasus already mentioned, deduped with pose winning
- Both \`generateFeedback\` and \`askCoach\` now include the timeline in the prompt with a hard rule: Claude may only reference timestamps from the list
- Output is post-snapped — every \`m:ss\` token Claude emits is matched against authoritative seconds within ±2s tolerance and rewritten (or left if nothing's close)
- Reorders \`useVideoAnalysis\` so MediaPipe runs **before** coach feedback, otherwise the timeline has nothing pose-derived to anchor on

## Why this should reduce hallucination
Two distinct failure modes:
1. **Pegasus drift** — TwelveLabs returns approximate seconds. We can't fix Pegasus, but we can refuse to amplify the drift.
2. **Claude restatement** — Claude rounds or invents numbers when summarizing Pegasus. The timeline + post-snap kills this.

## Test plan
- [x] 18 new unit tests in \`server/tests/timeline.test.ts\` covering parse, build, dedup, snap, format
- [x] Server + frontend typecheck clean
- [ ] Manual: upload a tennis video, inspect feedback timestamps — they should all match a pose phase transition
- [ ] Manual: ask the coach a question that would normally elicit a fake timestamp; reply should either snap or omit

## Caveats
- Pre-existing \`twelvelabs.test.ts\` failures (env module captures \`process.env\` at import time, so \`tests/setup.ts\` would need to set \`TWELVELABS_API_KEY\` — not introduced by this branch)
- Will conflict with #35 (persist-active-video) in \`useVideoAnalysis.ts\` — merge whichever lands first, resolve trivially in the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)