### PR TITLE
Skip TwelveLabs indexing, use direct video.url analyze

### DIFF
--- a/frontend/src/hooks/useVideoAnalysis.ts
+++ b/frontend/src/hooks/useVideoAnalysis.ts
@@ -1,6 +1,5 @@
 import { useState, useRef, useCallback } from "react";
 import { api, useMutation, useAction, type Id } from "@/lib/api";
-import { uploadAndIndexVideo, pollUntilReady } from "../lib/twelvelabs/videoIndexer";
 import { sampleVideoFrames, disposePoseLandmarker } from "../lib/mediapipe/pose-detector";
 import { scoreForehand } from "../lib/mediapipe/scoring-guides/forehand-scorer";
 import { scoreBackhand } from "../lib/mediapipe/scoring-guides/backhand-scorer";
@@ -91,7 +90,7 @@ export function useVideoAnalysis({
   const createSession = useMutation(api.sessions.createSession);
   const createAnalysis = useMutation(api.analyses.createAnalysis);
   const updateAnalysis = useMutation(api.analyses.updateAnalysis);
-  const analyzeVideo = useAction(api.twelvelabs.analyzeVideo);
+  const analyzeDirect = useAction(api.twelvelabs.analyzeDirect);
   const generateFeedback = useAction(api.coach.generateFeedback);
   const checkAndAwardBadges = useMutation(api.badges.checkAndAwardBadges);
 
@@ -135,43 +134,23 @@ export function useVideoAnalysis({
 
         if (abortRef.current) return;
 
-        // ── Step 2: TwelveLabs indexing ───────────────────────────────────────
+        // ── Step 2: Pegasus direct analysis ───────────────────────────────────
+        // Single call — TwelveLabs pulls the video from R2 itself, runs
+        // Pegasus, returns text. No more index/poll/analyze three-step dance.
         setStatus("analyzing");
 
-        const indexResult = await uploadAndIndexVideo({
-          sessionId: newSessionId,
-          analysisId: newAnalysisId,
-          sport,
-        });
-
-        if (abortRef.current) return;
-
-        // ── Step 3: Poll until TwelveLabs indexing is done ────────────────────
-        const pollResult = await pollUntilReady({
-          taskId: indexResult.taskId,
-          sessionId: newSessionId,
-          analysisId: newAnalysisId,
-        });
-
-        if (pollResult.status === "failed") {
-          throw new Error("TwelveLabs indexing failed");
-        }
-
-        if (abortRef.current) return;
-
-        // ── Step 4: Pegasus prompt analysis ───────────────────────────────────
         const prompt = `Analyze the ${sport} technique in this video. Focus on: ${requestedSections.join(", ")}.
 Identify strengths, weaknesses, and specific drills to improve each area.`;
 
-        await analyzeVideo({
+        await analyzeDirect({
+          sessionId: newSessionId,
           analysisId: newAnalysisId,
-          videoId: pollResult.videoId!,
           prompt,
         });
 
         if (abortRef.current) return;
 
-        // ── Step 5: MediaPipe pose scoring ────────────────────────────────────
+        // ── Step 3: MediaPipe pose scoring ────────────────────────────────────
         // Runs BEFORE coach feedback so the server can build an authoritative
         // timeline (pose key-frames + Pegasus anchors) and ground Claude's
         // timestamps against it.
@@ -205,7 +184,7 @@ Identify strengths, weaknesses, and specific drills to improve each area.`;
 
         if (abortRef.current) return;
 
-        // ── Step 6: Coach feedback (now grounded by pose timeline) ────────────
+        // ── Step 4: Coach feedback (now grounded by pose timeline) ────────────
         const newFeedbackId = await generateFeedback({
           sessionId: newSessionId,
           analysisId: newAnalysisId,
@@ -213,7 +192,7 @@ Identify strengths, weaknesses, and specific drills to improve each area.`;
 
         setFeedbackId(newFeedbackId);
 
-        // ── Step 7: Check and award badges ────────────────────────────────────
+        // ── Step 5: Check and award badges ────────────────────────────────────
         await checkAndAwardBadges({ userId });
 
         setStatus("ready");
@@ -232,7 +211,7 @@ Identify strengths, weaknesses, and specific drills to improve each area.`;
       createSession,
       createAnalysis,
       updateAnalysis,
-      analyzeVideo,
+      analyzeDirect,
       generateFeedback,
       checkAndAwardBadges,
     ]

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -178,6 +178,14 @@ export const api = {
       { analysisId: Id<"analyses">; videoId: string; prompt: string },
       string
     >("twelvelabs", "analyzeVideo"),
+    analyzeDirect: defAction<
+      {
+        sessionId: Id<"sessions">;
+        analysisId: Id<"analyses">;
+        prompt: string;
+      },
+      string
+    >("twelvelabs", "analyzeDirect"),
   },
 
   coach: {

--- a/server/src/routes/twelvelabs.ts
+++ b/server/src/routes/twelvelabs.ts
@@ -45,3 +45,15 @@ twelvelabs.post(
     (args) => svc.analyzeVideo(args)
   )
 );
+
+twelvelabs.post(
+  "/analyzeDirect",
+  rpc(
+    z.object({
+      sessionId: z.string(),
+      analysisId: z.string(),
+      prompt: z.string(),
+    }),
+    (args) => svc.analyzeDirect(args)
+  )
+);

--- a/server/src/services/twelvelabs.ts
+++ b/server/src/services/twelvelabs.ts
@@ -150,3 +150,49 @@ export async function analyzeVideo(args: {
 
   return result.data;
 }
+
+// Single-call replacement for index → poll → analyze. POST /analyze accepts a
+// `video.url` directly, so we hand TwelveLabs the R2 read URL and let it pull
+// the bytes itself. Saves the 30–90s indexing wait, removes the polling loop,
+// and collapses the failure surface to one HTTP call.
+//
+// Caveat: TwelveLabs requires a "publicly accessible" URL. Presigned R2 URLs
+// usually pass; if they don't, set R2_PUBLIC_BASE_URL and presignRead returns
+// the public-CDN form instead.
+export async function analyzeDirect(args: {
+  sessionId: string;
+  analysisId: string;
+  prompt: string;
+}): Promise<string> {
+  const sessRows = await sql`
+    SELECT video_storage_id FROM sessions WHERE id = ${args.sessionId}
+  `;
+  if (sessRows.length === 0) {
+    throw new ApiError(`Session ${args.sessionId} not found`, 404);
+  }
+  const videoUrl = await presignRead(sessRows[0]!.video_storage_id as string);
+  if (!videoUrl) throw new ApiError("Could not retrieve video URL from storage", 500);
+
+  await sql`
+    UPDATE sessions SET status = 'processing' WHERE id = ${args.sessionId}
+  `;
+
+  const result = (await tlFetch("/analyze", {
+    method: "POST",
+    body: JSON.stringify({
+      video: { type: "url", url: videoUrl },
+      prompt: args.prompt,
+      stream: false,
+    }),
+  })) as { data: string };
+
+  await sql`
+    UPDATE analyses SET twelve_labs_result = ${result.data}
+    WHERE id = ${args.analysisId}
+  `;
+  await sql`
+    UPDATE sessions SET status = 'complete' WHERE id = ${args.sessionId}
+  `;
+
+  return result.data;
+}


### PR DESCRIPTION
## Summary
- Replaces the index → poll → analyze three-step with a single `POST /analyze` call that takes `video.url` directly.
- TwelveLabs pulls the video from R2 itself; no `/indexes`, no `/tasks`, no polling loop.
- Drops the 30–90s indexing wait and the 5-min poll timeout that was leaving uploads stuck.

## Why
TwelveLabs indexing was failing/hanging for unclear reasons. The Pegasus sync `/analyze` endpoint accepts a video URL directly — much simpler, much faster, and one HTTP call to debug instead of three.

The old indexer + service functions are left in place as a one-line revert path in case TwelveLabs rejects presigned R2 URLs. If that happens, set `R2_PUBLIC_BASE_URL` (we already prefer it in `presignRead`).

## Test plan
- [ ] Upload a video → analysis completes in seconds, not minutes
- [ ] Coach feedback still references valid (grounded) timestamps
- [ ] Reload mid-flow → existing persistence still rehydrates session
- [ ] If TwelveLabs returns 4xx on the presigned URL: enable r2.dev public hostname and set `R2_PUBLIC_BASE_URL`