### PR TITLE
deleteSession + R2 orphan cleanup job

### DIFF
--- a/frontend/src/components/SessionLibrary.tsx
+++ b/frontend/src/components/SessionLibrary.tsx
@@ -6,10 +6,12 @@ import { FeedbackText } from "@/lib/timestamps";
 interface SessionLibraryProps {
   sessions: Session[];
   onSeek?: (seconds: number) => void;
+  onDelete?: (sessionId: string) => Promise<void> | void;
 }
 
-export function SessionLibrary({ sessions, onSeek }: SessionLibraryProps) {
+export function SessionLibrary({ sessions, onSeek, onDelete }: SessionLibraryProps) {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set());
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   if (sessions.length === 0) {
     return (
@@ -165,6 +167,26 @@ export function SessionLibrary({ sessions, onSeek }: SessionLibraryProps) {
                         Next Session Challenge
                       </h4>
                       <p className="text-sm text-foreground">{session.nextChallenge}</p>
+                    </div>
+                  )}
+
+                  {onDelete && (
+                    <div className="pt-2 border-t border-border">
+                      <button
+                        disabled={deletingId === session.id}
+                        onClick={async () => {
+                          if (!window.confirm("Delete this session? The video file will also be removed.")) return;
+                          setDeletingId(session.id);
+                          try {
+                            await onDelete(session.id);
+                          } finally {
+                            setDeletingId(null);
+                          }
+                        }}
+                        className="text-xs text-destructive hover:underline disabled:opacity-50 disabled:no-underline"
+                      >
+                        {deletingId === session.id ? "Deleting…" : "Delete session"}
+                      </button>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/tabs/Learn.tsx
+++ b/frontend/src/components/tabs/Learn.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { api, useAction, useQuery, type Id } from "@/lib/api";
+import { api, useAction, useMutation, useQuery, type Id } from "@/lib/api";
 import { Sport, ChatMessage, Session } from "@/types/playlog";
 import { SessionLibrary } from "@/components/SessionLibrary";
 import { UploadArea } from "@/components/UploadArea";
@@ -14,6 +14,7 @@ interface LearnProps {
 
 export function Learn({ sport, userId }: LearnProps) {
   const askCoach = useAction(api.coach.askCoach);
+  const deleteSession = useMutation(api.sessions.deleteSession);
   const videoPlayerRef = useRef<VideoPlayerHandle>(null);
 
   const { status, error, sessionId, currentVideo, analyze, reset } = useVideoAnalysis({
@@ -54,6 +55,21 @@ export function Learn({ sport, userId }: LearnProps) {
   const handleUpload = async (file: File) => {
     setForceUpload(false);
     await analyze(file);
+  };
+
+  // Deleting the active session would leave the player pointed at a row that
+  // no longer exists; reset local state to drop back into upload mode.
+  const handleDeleteSession = async (id: string) => {
+    try {
+      await deleteSession({ sessionId: id as Id<"sessions"> });
+      if (id === effectiveSessionId) {
+        setForceUpload(true);
+        reset();
+      }
+    } catch (err) {
+      console.error("Failed to delete session", err);
+      window.alert("Could not delete that session — try again.");
+    }
   };
 
   // Extract MediaPipe cue timestamps (in seconds) from the most-recent analysis
@@ -166,7 +182,7 @@ export function Learn({ sport, userId }: LearnProps) {
         <p className="text-xs text-destructive px-1">{error}</p>
       )}
 
-      <SessionLibrary sessions={sessions} onSeek={handleSeek} />
+      <SessionLibrary sessions={sessions} onSeek={handleSeek} onDelete={handleDeleteSession} />
 
       <ChatInterface
         messages={messages}

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -52,6 +52,10 @@ export const api = {
       { userId: Id<"users"> },
       SessionWithFeedback[]
     >("sessions", "listSessionsWithFeedback"),
+    deleteSession: defMutation<{ sessionId: Id<"sessions"> }, null>(
+      "sessions",
+      "deleteSession"
+    ),
   },
 
   analyses: {

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start": "tsx --env-file=.env src/index.ts",
     "build": "tsc -p tsconfig.json",
     "migrate": "tsx --env-file=.env src/db/migrate.ts",
+    "cleanup-r2": "tsx --env-file=.env src/jobs/r2-cleanup.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/server/src/jobs/r2-cleanup.ts
+++ b/server/src/jobs/r2-cleanup.ts
@@ -1,0 +1,79 @@
+// R2 orphan sweeper. Lists every object under videos/, diffs against
+// sessions.video_storage_id, deletes anything not referenced.
+//
+// Runnable as a script (`npm run cleanup-r2` from server/) — exits 0 on
+// success, prints a one-line summary. Designed to be called from cron, a
+// GitHub Action, or a manual /schedule prompt; safe to re-run (idempotent).
+
+import { sql } from "../db/client.js";
+import { deleteObject, listAllObjects } from "../storage/r2.js";
+
+export interface CleanupReport {
+  scannedObjects: number;
+  referencedKeys: number;
+  orphans: number;
+  deleted: number;
+  failures: Array<{ key: string; error: string }>;
+}
+
+export async function runR2Cleanup(opts: { dryRun?: boolean } = {}): Promise<CleanupReport> {
+  const dryRun = opts.dryRun ?? false;
+
+  const [allKeys, refRows] = await Promise.all([
+    listAllObjects("videos/"),
+    sql`SELECT video_storage_id FROM sessions WHERE video_storage_id IS NOT NULL`,
+  ]);
+
+  const referenced = new Set(refRows.map((r) => r.video_storage_id as string));
+  const orphans = allKeys.filter((k) => !referenced.has(k));
+
+  const failures: CleanupReport["failures"] = [];
+  let deleted = 0;
+
+  if (!dryRun) {
+    for (const key of orphans) {
+      try {
+        await deleteObject(key);
+        deleted += 1;
+      } catch (err) {
+        failures.push({
+          key,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return {
+    scannedObjects: allKeys.length,
+    referencedKeys: referenced.size,
+    orphans: orphans.length,
+    deleted,
+    failures,
+  };
+}
+
+// Script entry point. `npm run cleanup-r2` invokes this via tsx.
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const report = await runR2Cleanup({ dryRun });
+  console.log(
+    `[r2-cleanup] scanned=${report.scannedObjects} referenced=${report.referencedKeys} ` +
+      `orphans=${report.orphans} deleted=${report.deleted} failures=${report.failures.length}` +
+      (dryRun ? " (dry-run)" : "")
+  );
+  if (report.failures.length > 0) {
+    for (const f of report.failures) {
+      console.error(`  failed: ${f.key} — ${f.error}`);
+    }
+    process.exit(1);
+  }
+}
+
+// Only run main() when invoked directly, not when imported by tests.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error("[r2-cleanup] fatal:", err);
+    process.exit(1);
+  });
+}

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -7,6 +7,7 @@ import {
   mapSession,
 } from "../db/mappers.js";
 import { ApiError, rpc } from "../lib/route.js";
+import { deleteObject } from "../storage/r2.js";
 
 export const sessions = new Hono();
 
@@ -103,6 +104,34 @@ sessions.post(
       ORDER BY created_at DESC
     `;
     return rows.map(mapSession);
+  })
+);
+
+// Delete a session: drop the DB row (FK CASCADE handles analyses/messages/
+// feedback) and best-effort delete the R2 object. R2 failures are logged but
+// not surfaced — the nightly cleanup job will sweep any orphan we leave.
+sessions.post(
+  "/deleteSession",
+  rpc(SessionIdArgs, async ({ sessionId }) => {
+    const rows = await sql`
+      DELETE FROM sessions WHERE id = ${sessionId}
+      RETURNING video_storage_id
+    `;
+    if (rows.length === 0) {
+      throw new ApiError(`Session ${sessionId} not found`, 404);
+    }
+    const storageId = rows[0]!.video_storage_id as string | null;
+    if (storageId) {
+      try {
+        await deleteObject(storageId);
+      } catch (err) {
+        console.warn(
+          `[deleteSession] R2 delete failed for ${storageId}; cleanup job will sweep:`,
+          err
+        );
+      }
+    }
+    return null;
   })
 );
 

--- a/server/src/storage/r2.ts
+++ b/server/src/storage/r2.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
@@ -59,4 +60,26 @@ export async function deleteObject(storageId: string): Promise<void> {
       Key: storageId,
     })
   );
+}
+
+// Paginated list of every object key under `prefix`. The cleanup job uses this
+// to diff R2 against the sessions table; nothing in the request path should
+// call this (a full-bucket list is slow and not free).
+export async function listAllObjects(prefix = "videos/"): Promise<string[]> {
+  const keys: string[] = [];
+  let continuationToken: string | undefined;
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: env.r2.bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    );
+    for (const obj of res.Contents ?? []) {
+      if (obj.Key) keys.push(obj.Key);
+    }
+    continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined;
+  } while (continuationToken);
+  return keys;
 }

--- a/server/tests/r2-cleanup.test.ts
+++ b/server/tests/r2-cleanup.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const sqlCalls: Array<{ strings: TemplateStringsArray; values: unknown[] }> = [];
+let sqlResults: Array<unknown[]> = [];
+
+vi.mock("../src/db/client.js", () => {
+  function sql(strings: TemplateStringsArray, ...values: unknown[]) {
+    sqlCalls.push({ strings, values });
+    const next = sqlResults.shift() ?? [];
+    return Promise.resolve(next);
+  }
+  return { sql };
+});
+
+const listAllObjects = vi.fn();
+const deleteObject = vi.fn();
+
+vi.mock("../src/storage/r2.js", () => ({
+  listAllObjects: (prefix?: string) => listAllObjects(prefix),
+  deleteObject: (key: string) => deleteObject(key),
+  presignRead: vi.fn(),
+  presignUpload: vi.fn(),
+  newStorageId: vi.fn(),
+}));
+
+import { runR2Cleanup } from "../src/jobs/r2-cleanup.js";
+
+beforeEach(() => {
+  sqlCalls.length = 0;
+  sqlResults = [];
+  listAllObjects.mockReset();
+  deleteObject.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runR2Cleanup", () => {
+  test("deletes objects that aren't referenced by any session", async () => {
+    listAllObjects.mockResolvedValue([
+      "videos/keep-1",
+      "videos/orphan-1",
+      "videos/keep-2",
+      "videos/orphan-2",
+    ]);
+    sqlResults.push([
+      { video_storage_id: "videos/keep-1" },
+      { video_storage_id: "videos/keep-2" },
+    ]);
+
+    const report = await runR2Cleanup();
+
+    expect(report.scannedObjects).toBe(4);
+    expect(report.referencedKeys).toBe(2);
+    expect(report.orphans).toBe(2);
+    expect(report.deleted).toBe(2);
+    expect(report.failures).toEqual([]);
+    expect(deleteObject).toHaveBeenCalledTimes(2);
+    expect(deleteObject).toHaveBeenCalledWith("videos/orphan-1");
+    expect(deleteObject).toHaveBeenCalledWith("videos/orphan-2");
+  });
+
+  test("dry-run reports orphans without deleting", async () => {
+    listAllObjects.mockResolvedValue(["videos/a", "videos/b"]);
+    sqlResults.push([{ video_storage_id: "videos/a" }]);
+
+    const report = await runR2Cleanup({ dryRun: true });
+
+    expect(report.orphans).toBe(1);
+    expect(report.deleted).toBe(0);
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+
+  test("records per-object failures, keeps going", async () => {
+    listAllObjects.mockResolvedValue(["videos/orphan-1", "videos/orphan-2"]);
+    sqlResults.push([]);
+    deleteObject
+      .mockRejectedValueOnce(new Error("network timeout"))
+      .mockResolvedValueOnce(undefined);
+
+    const report = await runR2Cleanup();
+
+    expect(report.deleted).toBe(1);
+    expect(report.failures).toEqual([
+      { key: "videos/orphan-1", error: "network timeout" },
+    ]);
+  });
+
+  test("noop when bucket is empty", async () => {
+    listAllObjects.mockResolvedValue([]);
+    sqlResults.push([]);
+
+    const report = await runR2Cleanup();
+
+    expect(report).toEqual({
+      scannedObjects: 0,
+      referencedKeys: 0,
+      orphans: 0,
+      deleted: 0,
+      failures: [],
+    });
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+
+  test("noop when every object is referenced", async () => {
+    listAllObjects.mockResolvedValue(["videos/a", "videos/b"]);
+    sqlResults.push([
+      { video_storage_id: "videos/a" },
+      { video_storage_id: "videos/b" },
+    ]);
+
+    const report = await runR2Cleanup();
+
+    expect(report.orphans).toBe(0);
+    expect(deleteObject).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #33.

## Summary
- **`POST /api/sessions/deleteSession`** — drops the session row (FK CASCADE handles analyses/messages/feedback) and best-effort deletes the R2 object. R2 failures are logged, not surfaced; the cleanup job will sweep them.
- **R2 orphan cleanup script** (`server/src/jobs/r2-cleanup.ts`) — lists every `videos/*` key, diffs against `sessions.video_storage_id`, deletes orphans. Idempotent.
- **`npm run cleanup-r2`** runs the job. Pass `--dry-run` to report without deleting.
- **Frontend** — "Delete session" button on each expanded SessionLibrary card with confirm + spinner. Deleting the active session resets local state so the upload area reappears.

## Tests
5 new vitest cases on the cleanup job: orphan detection, dry-run, per-object failures, empty bucket, fully-referenced bucket. Existing 20 server tests still pass; the 11 pre-existing TWELVELABS_API_KEY failures are unchanged (env-import bug, separate issue).

## Test plan
- [ ] Delete a session in the UI — row disappears, R2 object is gone
- [ ] Delete the *active* session — player + coach reset, upload area appears
- [ ] `cd server && npm run cleanup-r2 -- --dry-run` — reports orphan count, deletes nothing
- [ ] `npm run cleanup-r2` — actually deletes; re-running shows 0 orphans

## Follow-up
Schedule the cleanup script (cron, GitHub Action, or `/schedule` agent). Not in this PR — depends on infra preference.