### PR TITLE
Fix Railway deploy: drop required .env, set Node engine

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,13 +4,16 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file=.env src/index.ts",
-    "start": "tsx --env-file=.env src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
+    "start": "tsx --env-file-if-exists=.env src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "migrate": "tsx --env-file=.env src/db/migrate.ts",
-    "cleanup-r2": "tsx --env-file=.env src/jobs/r2-cleanup.ts",
+    "migrate": "tsx --env-file-if-exists=.env src/db/migrate.ts",
+    "cleanup-r2": "tsx --env-file-if-exists=.env src/jobs/r2-cleanup.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
+  },
+  "engines": {
+    "node": ">=20.12.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",


### PR DESCRIPTION
## Summary
- Switches `--env-file=.env` → `--env-file-if-exists=.env` across `start`/`dev`/`migrate`/`cleanup-r2`. Railway injects env vars directly with no `.env` file in the container, so the original flag was crashing startup.
- Pins `engines.node >=20.12.0` (when `--env-file-if-exists` landed).
- Local dev unchanged — `.env` is still picked up when present.

## Required Railway dashboard config
This PR is the code half. Also needed in Railway:
1. **Service → Settings → Source → Root Directory** = `server`
2. **Variables** tab — add: `DATABASE_URL`, `R2_ENDPOINT`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_PUBLIC_BASE_URL`, `TWELVELABS_API_KEY`, `ANTHROPIC_API_KEY`, optionally `CORS_ORIGIN` once the Vercel URL is known.
3. Redeploy — Railpack will detect the `server/package.json`, find the `start` script, and serve on `$PORT`.