### PR TITLE
Best AND worst keyframe per phase + honest overall score

### DIFF
--- a/frontend/src/lib/mediapipe/landmark-schema.ts
+++ b/frontend/src/lib/mediapipe/landmark-schema.ts
@@ -172,6 +172,13 @@ export const FrameMetricsSchema = z.object({
 
   // Skip scoring this frame if below threshold (e.g. 0.6)
   visibilityConfidence: z.number().min(0).max(1),
+
+  // Set when this frame was selected as a best/worst exemplar of its phase.
+  // The coach uses these labels to compare strong vs weak reps in the prompt.
+  quality: z.enum(["best", "worst"]).optional(),
+  // Per-frame score (0–100) for the labeled exemplars only. Lets the coach
+  // reference concrete numbers ("strongest impact at 0:05 — 84 vs weakest 51").
+  score: z.number().min(0).max(100).optional(),
 });
 
 export type FrameMetrics = z.infer<typeof FrameMetricsSchema>;

--- a/frontend/src/lib/mediapipe/scorer-utils.ts
+++ b/frontend/src/lib/mediapipe/scorer-utils.ts
@@ -175,7 +175,10 @@ export function runScoringPipeline(
     allScored.push({ metrics, score, phase });
   }
 
-  // ── Select key frames — best-scoring frame per phase ─────────────────────
+  // ── Select key frames — best AND worst per phase ─────────────────────────
+  // Coaching value comes from contrast: "your strongest impact at 0:05 vs
+  // your weakest at 0:23". A highlight reel of best-only frames hides the
+  // exact reps the user needs to learn from.
   const phaseOrder: StrokePhase[] = [
     "preparation",
     "backswing",
@@ -185,15 +188,34 @@ export function runScoringPipeline(
   ];
 
   const keyFrames: FrameMetrics[] = [];
-  const keyScores: number[] = [];
 
   for (const phase of phaseOrder) {
     const inPhase = allScored.filter((f) => f.phase === phase);
     if (inPhase.length === 0) continue;
+
     const best = inPhase.reduce((a, b) => (a.score.overall >= b.score.overall ? a : b));
-    keyFrames.push(best.metrics);
-    keyScores.push(best.score.overall);
+    keyFrames.push({
+      ...best.metrics,
+      quality: "best",
+      score: Math.round(best.score.overall),
+    });
+
+    // Only emit a "worst" frame when it's actually a different rep — for
+    // single-instance phases there's nothing to contrast against.
+    if (inPhase.length > 1) {
+      const worst = inPhase.reduce((a, b) => (a.score.overall <= b.score.overall ? a : b));
+      if (worst.metrics.timestampMs !== best.metrics.timestampMs) {
+        keyFrames.push({
+          ...worst.metrics,
+          quality: "worst",
+          score: Math.round(worst.score.overall),
+        });
+      }
+    }
   }
+
+  // Sort chronologically so timeline display reads top-to-bottom in time order.
+  keyFrames.sort((a, b) => a.timestampMs - b.timestampMs);
 
   // ── Summary aggregation ───────────────────────────────────────────────────
   const avg = (arr: number[]) =>
@@ -209,8 +231,12 @@ export function runScoringPipeline(
         followThroughFrames.length
       : 0;
 
-  const overallScore = keyScores.length > 0
-    ? Math.round(keyScores.reduce((a, b) => a + b, 0) / keyScores.length)
+  // Honest session score — average across every scored frame, not just the
+  // best per phase. The old version (best-per-phase average) systematically
+  // inflated scores and undermined coaching credibility ("78 overall, but my
+  // form fell apart half the time").
+  const overallScore = allScored.length > 0
+    ? Math.round(allScored.reduce((s, f) => s + f.score.overall, 0) / allScored.length)
     : 0;
 
   return {

--- a/server/src/lib/timeline.ts
+++ b/server/src/lib/timeline.ts
@@ -45,6 +45,8 @@ export function extractTimestampsFromText(text: string): number[] {
 interface KeyFrameLite {
   timestampMs: number;
   phase: string;
+  quality?: "best" | "worst";
+  score?: number;
 }
 
 interface PoseAnalysisLite {
@@ -73,10 +75,16 @@ export function momentsFromPoseAnalysis(serialized: string | null | undefined): 
     for (const kf of r.keyFrames ?? []) {
       const seconds = Math.round(kf.timestampMs / 1000);
       const phase = kf.phase.replace(/_/g, " ");
-      const label = technique
+      // Surface the best/worst tag + per-frame score so the coach has the
+      // contrast spelled out: "0:05 forehand impact (BEST 84)" vs
+      // "0:23 forehand impact (WORST 51)".
+      const qualityTag = kf.quality
+        ? ` (${kf.quality.toUpperCase()}${kf.score !== undefined ? ` ${kf.score}` : ""})`
+        : "";
+      const base = technique
         ? `${fmt(seconds)} ${technique} ${phase}`
         : `${fmt(seconds)} ${phase}`;
-      out.push({ seconds, label, source: "pose" });
+      out.push({ seconds, label: `${base}${qualityTag}`, source: "pose" });
     }
   }
   return out;

--- a/server/src/routes/coach.ts
+++ b/server/src/routes/coach.ts
@@ -101,7 +101,13 @@ coach.post(
 Authoritative timeline (the ONLY moments you may reference):
 ${timelineForPrompt}
 
-Generate coaching feedback as JSON: a 2-3 sentence summary, an array of strengths (each with a timestamp from the timeline above), an array of improvements (each formatted as "issue — timestamp — fix"), and an array of drills (one per improvement).
+The timeline includes BEST and WORST exemplars per phase (with scores). Coach
+the contrast: when a phase has both, your feedback for that phase MUST
+reference both moments — what made the best work and what broke down in the
+worst. A coach who only celebrates highlights is a flatterer; a coach who
+only lists problems is discouraging. Do both, in the same beat.
+
+Generate coaching feedback as JSON: a 2-3 sentence summary, an array of strengths (each with a timestamp from the timeline above), an array of improvements (each formatted as "issue — timestamp — fix" and citing the WORST timestamp where applicable), and an array of drills (one per improvement).
 
 Hard rule: every timestamp you use MUST come from the timeline above, written in m:ss format. If a moment isn't in the timeline, describe it without a timestamp rather than guess.`;
 
@@ -224,7 +230,7 @@ coach.post(
     );
     const authoritativeSeconds = timeline.map((m: TimelineMoment) => m.seconds);
     const timelineSection = timeline.length > 0
-      ? `\n\nAuthoritative timeline (the ONLY moments you may reference; m:ss):\n${formatTimelineForPrompt(timeline)}\n\nHard rule: every timestamp you use MUST come from the timeline above. If a moment isn't in the timeline, describe it without a timestamp.`
+      ? `\n\nAuthoritative timeline (the ONLY moments you may reference; m:ss). Entries tagged BEST/WORST are exemplars of the same phase — when both appear, contrast them in your reply rather than picking one.\n${formatTimelineForPrompt(timeline)}\n\nHard rule: every timestamp you use MUST come from the timeline above. If a moment isn't in the timeline, describe it without a timestamp.`
       : "";
 
     const systemContext = latestFeedback

--- a/server/tests/timeline.test.ts
+++ b/server/tests/timeline.test.ts
@@ -42,6 +42,19 @@ describe("momentsFromPoseAnalysis", () => {
     expect(moments[2]).toEqual({ seconds: 5, label: "0:05 forehand impact", source: "pose" });
   });
 
+  test("surfaces best/worst quality + score in the label", () => {
+    const labeled = JSON.stringify({
+      technique: "forehand",
+      keyFrames: [
+        { timestampMs: 5000, phase: "impact", quality: "best",  score: 84 },
+        { timestampMs: 23000, phase: "impact", quality: "worst", score: 51 },
+      ],
+    });
+    const moments = momentsFromPoseAnalysis(labeled);
+    expect(moments[0]!.label).toBe("0:05 forehand impact (BEST 84)");
+    expect(moments[1]!.label).toBe("0:23 forehand impact (WORST 51)");
+  });
+
   test("returns empty for null/invalid input", () => {
     expect(momentsFromPoseAnalysis(null)).toEqual([]);
     expect(momentsFromPoseAnalysis("not json")).toEqual([]);


### PR DESCRIPTION
## Why
The scorer was a highlight reel: for each phase it kept only the single highest-scoring frame across the entire video. A user who swings 10 times saw feedback on their best impact, never their worst — exactly the rep they need to learn from. The aggregate overallScore was also inflated because it averaged best-per-phase rather than every frame.

## What changed
- **\`scorer-utils.ts\`** — emit BOTH best and worst per phase when there's more than one frame in that phase. Each tagged with a new optional \`quality\` + \`score\` on FrameMetrics. Sorted chronologically.
- **\`scorer-utils.ts\`** — \`overallScore\` is now the average of every scored frame (honest), not best-per-phase (flattering).
- **\`timeline.ts\`** — labels surface the contrast: \`0:05 forehand impact (BEST 84)\` vs \`0:23 forehand impact (WORST 51)\`.
- **\`coach.ts\`** — both prompts (generateFeedback + askCoach) now require Claude to contrast best vs worst when both appear, rather than picking the prettier moment.

## Tests
New vitest case covering the BEST/WORST label rendering. All 26 server tests pass; the 11 pre-existing twelvelabs failures are the env-import bug, unchanged.

## Test plan
- [ ] Upload a multi-swing clip — feedback now references both strong and weak reps
- [ ] Overall score lower than before for the same video (this is correct — the old number was fake)
- [ ] Coach chat: ask "what should I work on" — reply cites the WORST timestamps