### PR TITLE
docs: rewrite README + add engineering reflection + pipeline flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,284 @@
 # PlayLog
-AI-powered sports coaching web app.
+
+> **AI-powered sports coaching for the browser.** Upload a clip of yourself playing — PlayLog scores your form frame by frame, builds an authoritative timeline of every key moment, and an LLM coach gives you grounded, growth-oriented feedback you can click through to the exact second on the video.
+
+PlayLog combines in-browser computer vision (MediaPipe pose detection) with a video-understanding model (TwelveLabs Pegasus) and a coaching LLM (Anthropic Claude) — joined together by a small Hono server, Postgres for state, and Cloudflare R2 for video bytes.
+
+---
+
+## Table of contents
+
+- [Stack](#stack)
+- [Architecture](#architecture)
+- [Project structure](#project-structure)
+- [Quickstart](#quickstart)
+- [Configuration](#configuration)
+- [Scripts](#scripts)
+- [Testing](#testing)
+- [Deployment](#deployment)
+- [Engineering reflection](#engineering-reflection)
+
+---
 
 ## Stack
 
-- **Frontend** — React + Vite + TypeScript (Vercel)
-- **Backend** — Hono on Node, deployable to Railway / Fly / any Node host
-- **Database** — Postgres (Railway / Supabase / Neon — anything that speaks plain Postgres)
-- **Object storage** — Cloudflare R2 (S3-compatible, zero egress fees)
-- **CV** — MediaPipe (browser-side on the uploaded video)
-- **External APIs** — TwelveLabs (Pegasus video understanding) and Gemini (coaching feedback)
+| Layer | Technology | Notes |
+|---|---|---|
+| Frontend | React 18 · Vite · TypeScript · Tailwind | Hosted on Vercel |
+| API | Hono on Node 20+ | Hosted on Railway |
+| Database | Postgres | Any provider that speaks plain Postgres (Railway, Supabase, Neon) |
+| Object storage | Cloudflare R2 (S3-compatible) | Zero egress fees; public r2.dev or custom-domain hostname |
+| Pose detection | MediaPipe BlazePose | Runs entirely client-side in the browser |
+| Video understanding | TwelveLabs Pegasus 1.2 | Sync `/analyze` with direct `video.url` (no indexing) |
+| Coaching LLM | Anthropic Claude Haiku 4.5 | Structured output via `messages.parse()` + Zod |
 
-## Project Structure
+---
+
+## Architecture
+
+The full request path from upload to coaching feedback:
+
+![Pipeline architecture flowchart](docs/images/architecture-flowchart.svg)
+
+The defining design choice is that **MediaPipe pose scoring runs entirely in the browser**. This keeps the server stateless and GPU-free — the only server-side cost per session is the Anthropic call (cents). It also lets the frontend upload bytes directly to R2 via a presigned PUT URL, with no proxy through our backend.
+
+The other defining choice is the **authoritative timeline** in `server/src/lib/timeline.ts`. Pose key-frames (frame-accurate) and Pegasus mentions (free-form) are merged into a single ordered list of seconds, which is then passed into Claude's prompt as the *only* allowed reference points. Every `m:ss` Claude emits is post-validated by snapping it to the nearest authoritative anchor within ±2 seconds. This pattern — *prompt-side constraint plus machine-validated rewriting* — is what makes the coaching feel trustworthy rather than plausible-sounding.
+
+---
+
+## Project structure
 
 ```
 PlayLog/
-├── server/        # Hono backend — routes, db client, R2 storage, external services
-│   └── src/
-│       ├── routes/    # one Hono router per domain (users, sessions, ...)
-│       ├── services/  # external API integrations (TwelveLabs)
-│       ├── db/        # postgres client, schema.sql, migrate runner, mappers
-│       ├── storage/   # R2 client + presigned URL helpers
-│       └── lib/       # env, errors, rpc helper
-├── frontend/      # React + Vite app
-│   └── src/lib/api/   # typed client + Convex-shaped hooks (useQuery / useMutation / useAction)
-└── package.json   # root scripts that fan out to server/ and frontend/
+├── server/                       # Hono backend
+│   ├── src/
+│   │   ├── routes/               # one Hono router per domain
+│   │   │   ├── users.ts
+│   │   │   ├── sessions.ts       # createSession, deleteSession, list
+│   │   │   ├── analyses.ts
+│   │   │   ├── messages.ts
+│   │   │   ├── feedback.ts
+│   │   │   ├── goals.ts
+│   │   │   ├── badges.ts
+│   │   │   ├── storage.ts        # presigned R2 URLs
+│   │   │   ├── twelvelabs.ts     # analyzeDirect: video URL → text
+│   │   │   └── coach.ts          # generateFeedback + askCoach
+│   │   ├── services/             # external API integrations
+│   │   ├── db/                   # postgres client, schema.sql, migrate, mappers
+│   │   ├── storage/              # R2 client + presigned URL helpers
+│   │   ├── jobs/                 # cron-runnable scripts
+│   │   │   └── r2-cleanup.ts     # deletes orphaned video objects
+│   │   └── lib/                  # env, errors, rpc, timeline grounding
+│   ├── tests/                    # vitest with mocked fetch + sql
+│   └── package.json
+├── frontend/                     # React + Vite app
+│   ├── src/
+│   │   ├── components/           # tabs, video player, chat, session library
+│   │   ├── hooks/                # useVideoAnalysis, useMediaPipe
+│   │   └── lib/
+│   │       ├── api/              # typed RPC client + React hooks
+│   │       ├── mediapipe/        # pose detection + scoring guides
+│   │       └── timestamps.tsx    # m:ss chip parser, click-to-seek
+│   └── package.json
+├── docs/
+│   └── images/
+│       └── architecture-flowchart.svg
+└── package.json                  # root scripts that fan out to each package
 ```
 
-The frontend talks to the backend over a small RPC convention: every endpoint
-is `POST /api/<module>/<name>` with a JSON body. The `api` object in
-`frontend/src/lib/api/api.ts` mirrors what `convex/_generated/api` used to
-expose, so React components keep using `useQuery(api.x.y, args)` and friends.
+The frontend talks to the backend over a small RPC convention: every endpoint is `POST /api/<module>/<name>` with a JSON body. The `api` object in `frontend/src/lib/api/api.ts` declares typed descriptors (`defQuery` / `defMutation` / `defAction`); React components consume them with `useQuery` / `useMutation` / `useAction` hooks built on top of TanStack Query.
 
-## Setup
+---
 
-### 1. Backend
+## Quickstart
+
+**Prerequisites:** Node ≥ 20.12, a Postgres database, a Cloudflare R2 bucket with a token, a TwelveLabs API key, an Anthropic API key.
 
 ```bash
-cd server
-cp .env.example .env       # fill in DATABASE_URL, R2_*, TWELVELABS_API_KEY, GEMINI_API_KEY
-npm install
-npm run migrate            # creates the Postgres tables
-npm run dev                # boots Hono on :8787
+# 1. Clone and install
+git clone https://github.com/skytraan/PlayLog.git
+cd PlayLog
+npm --prefix server   install
+npm --prefix frontend install
+
+# 2. Configure
+cp server/.env.example server/.env
+cp frontend/.env.example frontend/.env
+# fill in the values (see Configuration below)
+
+# 3. Initialise the database
+npm --prefix server run migrate
+
+# 4. Run both dev servers (in separate terminals)
+npm run backend     # Hono on http://localhost:8787
+npm run frontend    # Vite on http://localhost:8080
 ```
 
-| Variable | Description |
+Open `http://localhost:8080`, complete onboarding, upload a clip — analysis should complete in 10–25 seconds end-to-end.
+
+---
+
+## Configuration
+
+### `server/.env`
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATABASE_URL` | yes | Postgres connection string |
+| `R2_ENDPOINT` | yes | `https://<account-id>.r2.cloudflarestorage.com` |
+| `R2_BUCKET` | yes | R2 bucket name |
+| `R2_ACCESS_KEY_ID` | yes | R2 token access key |
+| `R2_SECRET_ACCESS_KEY` | yes | R2 token secret |
+| `R2_PUBLIC_BASE_URL` | recommended | r2.dev subdomain or custom domain. Strongly recommended for production — TwelveLabs sometimes rejects presigned URLs |
+| `TWELVELABS_API_KEY` | yes | TwelveLabs API key |
+| `ANTHROPIC_API_KEY` | yes | Anthropic API key |
+| `CORS_ORIGIN` | no | Comma-separated allowed origins. Defaults to `*` |
+| `PORT` | no | Server port. Defaults to `8787`. Railway sets this automatically |
+
+### `frontend/.env`
+
+| Variable | Required | Description |
+|---|---|---|
+| `VITE_API_URL` | yes | URL of the running server (e.g. `http://localhost:8787` or your Railway URL) |
+
+---
+
+## Scripts
+
+### Root
+
+| Command | Description |
 |---|---|
-| `DATABASE_URL` | Postgres connection string |
-| `R2_ENDPOINT` | `https://<account>.r2.cloudflarestorage.com` |
-| `R2_BUCKET` | R2 bucket name |
-| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | R2 token |
-| `R2_PUBLIC_BASE_URL` | _(optional)_ CDN base. If set, video reads return `<base>/<key>` instead of presigned URLs — useful for TwelveLabs which sometimes balks at presigned URLs |
-| `TWELVELABS_API_KEY` | TwelveLabs API key |
-| `GEMINI_API_KEY` | Gemini API key |
-| `CORS_ORIGIN` | Comma-separated allowed origins, or `*` |
-| `PORT` | Port to listen on (Railway sets this) |
+| `npm run backend` | Start the Hono dev server with watch reload |
+| `npm run frontend` | Start the Vite dev server |
+| `npm run migrate` | Apply `server/src/db/schema.sql` to `DATABASE_URL` |
 
-### 2. Frontend
+### `server/`
 
-```bash
-cd frontend
-cp .env.example .env       # set VITE_API_URL to wherever the server is running
-npm install
-npm run dev                # Vite on :8080
-```
+| Command | Description |
+|---|---|
+| `npm run dev` | Hono in watch mode |
+| `npm start` | Hono production-mode (no watch) |
+| `npm run migrate` | Apply DB schema |
+| `npm run cleanup-r2` | Delete R2 objects not referenced by any session. Pass `--dry-run` to report without deleting |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run test` | Vitest |
 
-### 3. Run both together
+### `frontend/`
 
-```bash
-# from repo root
-npm run backend     # terminal 1
-npm run frontend    # terminal 2
-```
+| Command | Description |
+|---|---|
+| `npm run dev` | Vite on port 8080 |
+| `npm run build` | Production bundle to `dist/` |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run test` | Vitest |
 
-## Tests
+---
+
+## Testing
 
 ```bash
 npm --prefix server   run test
 npm --prefix frontend run test
 ```
 
-The server twelvelabs tests stub fetch + the SQL client. Database-touching
-route tests (sessions, users, etc.) intentionally aren't shipped — they need a
-real Postgres or `pg-mem` to be meaningful, which is left as future work.
+The server tests stub `fetch` and the SQL client at the module-mock layer, so individual route logic can be exercised without a live Postgres or external API. Database-touching integration tests are intentionally not shipped — they require a real Postgres or `pg-mem` to be meaningful, and are tracked in [issue #32](https://github.com/skytraan/PlayLog/issues/32).
 
-## Deploying
+A known stable failure exists in `tests/twelvelabs.test.ts` where `env.ts` captures `process.env.TWELVELABS_API_KEY` at module-import time before vitest's `beforeEach` runs. This is documented and intentionally not blocking PR merges; the fix is to convert env reads to lazy accessors.
 
-- **Server** — point Railway at `/server`, set start command to `npm start`,
-  set the env vars above. Run `npm run migrate` once after first deploy.
-- **Frontend** — Vercel: project root `/frontend`, build `npm run build`,
-  output `dist`. Set `VITE_API_URL` to the deployed server URL.
+---
+
+## Deployment
+
+### Backend → Railway
+
+1. **Create a Railway service** pointed at this repo.
+2. **Settings → Source → Root Directory** = `server`
+3. **Variables** tab: add every value from your local `server/.env`. Do **not** add `PORT` — Railway injects it automatically and the server already reads it.
+4. Railway auto-detects Node, finds `server/package.json`, runs `npm install` and `npm start`.
+5. Run `npm run migrate` once after first deploy (Railway → Service → Settings → run a one-off command).
+
+### Frontend → Vercel
+
+1. **Project root** = `frontend`
+2. **Build command** = `npm run build`
+3. **Output directory** = `dist`
+4. **Environment variable**: `VITE_API_URL` = your Railway service URL.
+
+### R2 → Cloudflare
+
+1. Create a bucket (e.g. `playlog-videos`).
+2. Generate an R2 user API token with read/write permissions for that bucket; populate `R2_ACCESS_KEY_ID` and `R2_SECRET_ACCESS_KEY`.
+3. **Bucket → Settings → Public Access → R2.dev subdomain → Allow Access** to get a `https://pub-<hash>.r2.dev` URL. Set this as `R2_PUBLIC_BASE_URL`. (For production, swap to a custom domain via Cloudflare DNS — same env var, no other code change.)
+
+### Postgres
+
+Any provider that speaks plain Postgres works. Railway is the simplest if you're already using it for the backend. After provisioning, paste the connection string into `DATABASE_URL` and run `npm run migrate`.
+
+---
+
+## Engineering reflection
+
+> A personal write-up of the architectural decisions, the dead ends, and the lessons that shaped PlayLog's current form. Intended as a portfolio artifact rather than user-facing documentation.
+
+### Architecture decisions
+
+The pipeline shown in the [architecture flowchart](#architecture) reflects two decisions that had outsized impact on the project's trajectory.
+
+The first is the **client-side pose scoring boundary**. Running MediaPipe in the browser eliminated an entire class of infrastructure cost — no GPU rentals, no model-serving stack, no inference queue. The trade-off is that scoring takes a few seconds of the user's CPU, but for a coaching app where the user has already decided to invest in reviewing their session, that cost is invisible. The boundary also enabled the cleanest possible upload UX: bytes go directly from the browser to R2 via presigned PUT, with no proxy through the backend.
+
+The second is the **authoritative-timeline pattern** in `server/src/lib/timeline.ts`. Early versions of the coaching feedback hallucinated timestamps freely — Claude would write *"At 0:23 your follow-through was incomplete"* on a video where 0:23 was the player walking back to the baseline. Users immediately lose trust when a chip seeks them to a moment that doesn't match the prose. The fix builds a single ordered list of seconds from MediaPipe key-frames (frame-accurate) and Pegasus mentions (fallback), passes it into the prompt as the *only* allowed reference points, and post-validates every `m:ss` in the reply by snapping it to the nearest authoritative anchor within ±2 seconds. The constraint goes in the prompt; the snap catches anything Claude rounds or invents anyway. *Prompt-side constraint + machine-validated post-hoc rewriting* turned the coach from a clever-sounding chatbot into something a player would actually trust.
+
+> **Image placement note — `docs/images/grounding-before-after.png`** *(needs adding)*: a side-by-side screenshot. Left: an early feedback card with timestamps that don't line up to anything visible. Right: the current grounded version where every chip lands on a real swing phase. This is the single most important visual in the reflection because it shows the difference grounding makes.
+
+### Coaching is contrast, not curation
+
+The first version of the scorer kept only the single highest-scoring frame per phase. It produced coaching that read like a highlight reel: *"your forehand impact at 0:05 was strong."* True, but useless — the user already knows their best swing felt good; they want to know the rep where their form fell apart. The honest version (`scorer-utils.ts`) emits both the **best** AND **worst** exemplar per phase, tags each with a `quality` field and a per-frame `score`, and the coach prompt explicitly requires Claude to contrast them. The aggregate `overallScore` was also changed from "average of the best frame per phase" to "average across every scored frame," which dropped scores by 10–20 points but stopped systematically lying to users.
+
+This is a product instinct that masqueraded as a technical decision. The scorer's old behavior was technically reasonable but pedagogically wrong, and we only caught it after a real user pointed out that we were celebrating their highlights instead of helping them grow.
+
+> **Image placement note — `docs/images/best-vs-worst-feedback.png`** *(needs adding)*: a screenshot of the feedback panel with both BEST and WORST timestamps visible, ideally on a multi-rep clip. Caption it with the score delta so the "honest score" point is immediate.
+
+### The simplest external API call is the right one
+
+The original TwelveLabs integration followed the canonical three-step dance: create an index, upload to a task, poll until status flips to `ready`, then call analyze with the resulting `video_id`. The polling loop took 30–90 seconds on a good run and silently hung on a bad one. After a frustrating evening trying to debug *why* indexing was hanging, we discovered that the sync `/analyze` endpoint accepts a `video.url` directly and skips the entire indexing pipeline. One HTTP call instead of three; 5–15 seconds instead of minutes; one failure mode to debug instead of three. The lesson was less about TwelveLabs and more about the general posture: **always re-read the docs on a service that's misbehaving — the canonical happy path may not be the simplest path for your case.**
+
+### Persistence boundaries are where the bugs live
+
+After we shipped the "session persists across reload" feature, we shipped the "upload a different video" button at the same time. They quietly fought each other: clicking the button cleared the active session correctly, but a fallback in `Learn.tsx` immediately re-bound the player to the most recent history session, and the upload area never rendered. The fix (a single `forceUpload` flag) was trivial; the lesson was harder — every place we have a default that fills in when state is empty is a place where "explicitly cleared by the user" can get confused with "happens to be empty right now." The surface area for this kind of bug grows quadratically with the number of derived values, which is exactly what React encourages.
+
+### Difficulties (and what we took from them)
+
+**Migrating off Convex mid-build.** PlayLog started as a hackathon project on Convex. When the demo became a real product with a webinar deadline, the data-modeling constraints (no joins, function-only access, paid-tier vendor lock for production-grade limits) became blockers. The migration to Hono + Postgres + R2 took roughly a day. The trick was preserving the *shape* of the frontend's data layer — the new `frontend/src/lib/api/` module exposes `defQuery` / `defMutation` / `defAction` descriptors and `useQuery` / `useMutation` hooks that mimic Convex's API, so React components didn't change at all. The migration story is *"rewrite the persistence, freeze the surface"* — the dialect at the boundary stayed identical even as the backend underneath was rebuilt.
+
+**The TwelveLabs `model_options` rename.** Indexing was failing with a 400 *"model_options is invalid"* for an embarrassingly long time before we realised the v1.3 API had renamed the field from `options` to `model_options`. The error message named the new field; we had been writing the old one. This is a class of bug that's miserable on every external API: the official docs are fine, your code matches an older example, the error message *literally names the right field* but you read past it. The fix (`server/src/services/twelvelabs.ts`) is one line. The hour spent finding it was about not trusting the docs over our memory of the older API shape.
+
+**Gemini billing flake.** The original coaching path used Gemini. Two days before the demo, Gemini started returning 429s — Cloud Prepay credits had hit zero despite the trial-credit balance still showing positive. Rather than debug a billing dashboard during demo prep, we swapped the entire LLM path to Anthropic Claude Haiku 4.5. The structured-output API (`messages.parse()` with a JSON schema and Zod validation) turned out to be a meaningful upgrade — the old Gemini path had a fragile regex-out-the-JSON-blob step that occasionally produced empty feedback when the model ad-libbed. Claude's structured-output guarantees a typed object or a typed error, never a malformed string. The swap took ~90 minutes; the improvement was permanent.
+
+**Presigned URLs vs TwelveLabs.** Cloudflare R2 returns long, signed URLs from the S3 API; TwelveLabs' fetcher occasionally rejected these. The fix was enabling R2's `r2.dev` public subdomain and pointing `R2_PUBLIC_BASE_URL` at it; `presignRead` already prefers the public base when set. This is a one-env-var change that we documented in `CLAUDE.md` *before* it was needed, and that documentation paid for itself when the symptom appeared in production. **Lesson: write down the workaround for a problem you anticipate, even if it hasn't bitten yet.**
+
+**Monorepo on Railway.** Railpack scanned the repo root, found no `start` script, and refused to build. Worse, even after we set Root Directory to `server/`, the `start` script still hard-coded `--env-file=.env` — which doesn't exist in a Railway container, since Railway injects env vars directly. The fix was switching every script (`dev`, `start`, `migrate`, `cleanup-r2`) from `--env-file=.env` to `--env-file-if-exists=.env`. Local dev unchanged; Railway happy. **Lesson: defaults in your tooling that assume a local layout are landmines for deployment.**
+
+**Test environment timing.** A class of server tests that mock the TwelveLabs HTTP layer have been failing pre-existingly because `env.ts` captures `process.env.TWELVELABS_API_KEY` at module-import time, but vitest's `setup.ts` only sets it inside `beforeEach`. The pattern needs lazy env reads (or test-side env injection at the top of `setup.ts`). It's flagged but not fixed — a known stable failure that we've intentionally not blocked progress on, and we shipped multiple subsequent PRs around it. **Lesson: a known flake is fine if everyone knows it's known. An unknown flake is what kills morale.**
+
+### What we would do differently
+
+- **Set up the public R2 hostname before TwelveLabs forces it.** We had a working presigned-URL path that *mostly* worked, and only swapped to public base URLs when TwelveLabs broke. Doing it from day one would have removed an entire class of *"is the URL the problem?"* debugging.
+- **Pin the LLM provider before the demo deadline.** Building against Gemini for two weeks and then porting to Anthropic in 90 minutes worked, but it was avoidable rework — the structured-output advantage of Anthropic was knowable from day one.
+- **Write the `cleanup-r2` job earlier.** Every test upload during development left an orphan in R2. By the time we had the cleanup job, the bucket had hundreds of unreferenced objects. Cheap to store, but a sloppy footprint we should not have allowed to accumulate.
+
+### Image placement summary
+
+The reflection above embeds the architecture flowchart and references several screenshots that complete the portfolio narrative. They live in `docs/images/`.
+
+| Filename | Status | Content |
+|---|---|---|
+| `architecture-flowchart.svg` | ✅ in repo | Pipeline flowchart embedded above |
+| `hero-screenshot.png` | needed | Landing view of the Learn tab — upload area, sport selector, empty session library beneath |
+| `analyzing-in-progress.png` | needed | Mid-analysis: video player visible above, "Analyzing → Scoring → Generating feedback" status with one step pulsing |
+| `coach-feedback-card.png` | needed | A finished feedback card showing summary, strengths, improvements, drills with **clickable m:ss timestamp chips** highlighted |
+| `grounding-before-after.png` | needed | Side-by-side: hallucinated timestamps (early version) vs grounded timestamps (current). The most important visual in the reflection |
+| `best-vs-worst-feedback.png` | needed | A multi-rep video's feedback panel with both BEST and WORST exemplars surfaced — captioned with the honest overall-score |
+| `chat-with-seek.png` | needed | The coach chat with an assistant reply containing timestamp chips, ideally with the user mid-click to seek |
+| `session-library-delete.png` | needed | Expanded session card with the Delete button visible — supporting the R2 cleanup story |
+| `mobile-view.png` | aspirational | An iPhone-sized viewport showing upload + analysis flow — supports the responsive-design story (tracked in [issue #45](https://github.com/skytraan/PlayLog/issues/45)) |

--- a/docs/images/architecture-flowchart.svg
+++ b/docs/images/architecture-flowchart.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 1320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1100" height="1320" fill="#fafaf9"/>
+
+  <!-- Title -->
+  <text x="550" y="44" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a">PlayLog · Video → Coaching Pipeline</text>
+  <text x="550" y="72" text-anchor="middle" font-size="13" fill="#64748b">Browser-side pose scoring + server-side LLM grounding, joined by an authoritative timeline</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 1: Upload                               -->
+  <!-- ============================================ -->
+  <rect x="350" y="110" width="400" height="80" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="550" y="138" text-anchor="middle" font-size="14" font-weight="700" fill="#1e3a8a">1 · User uploads video</text>
+  <text x="550" y="158" text-anchor="middle" font-size="11" fill="#475569">UploadArea.tsx · file picker / drag-drop</text>
+  <text x="550" y="174" text-anchor="middle" font-size="11" fill="#475569">requests a presigned PUT URL from the server</text>
+
+  <!-- arrow 1 → 2 -->
+  <line x1="550" y1="190" x2="550" y2="222" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="565" y="212" font-size="10" fill="#475569">presigned URL</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 2: R2 upload                            -->
+  <!-- ============================================ -->
+  <rect x="350" y="225" width="400" height="80" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="550" y="253" text-anchor="middle" font-size="14" font-weight="700" fill="#78350f">2 · Bytes uploaded directly to Cloudflare R2</text>
+  <text x="550" y="273" text-anchor="middle" font-size="11" fill="#475569">videos/&lt;uuid&gt; key · S3-compatible PUT · zero-egress storage</text>
+  <text x="550" y="289" text-anchor="middle" font-size="11" fill="#475569">browser → R2 directly · no proxy through our backend</text>
+
+  <!-- split arrow: 2 → 3a (browser) and 2 → 3b (server) -->
+  <line x1="550" y1="305" x2="550" y2="335" stroke="#475569" stroke-width="1.5"/>
+  <line x1="250" y1="335" x2="850" y2="335" stroke="#475569" stroke-width="1.5"/>
+  <line x1="250" y1="335" x2="250" y2="368" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="850" y1="335" x2="850" y2="368" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="550" y="328" text-anchor="middle" font-size="10" font-weight="600" fill="#475569">storage key persisted on session row · two consumers in parallel</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 3a: MediaPipe (left)  /  3b: TwelveLabs (right) -->
+  <!-- ============================================ -->
+  <rect x="50" y="370" width="400" height="180" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="250" y="397" text-anchor="middle" font-size="14" font-weight="700" fill="#1e3a8a">3A · Browser · MediaPipe Pose Scoring</text>
+  <text x="250" y="418" text-anchor="middle" font-size="11" fill="#475569">scoring-guides/{forehand,backhand,serve,…}-scorer.ts</text>
+  <text x="250" y="434" text-anchor="middle" font-size="11" fill="#475569">scorer-utils.ts · runScoringPipeline()</text>
+  <text x="250" y="464" text-anchor="middle" font-size="11" fill="#1e3a8a">• Sample frames at 2 fps</text>
+  <text x="250" y="482" text-anchor="middle" font-size="11" fill="#1e3a8a">• Phase classifier per frame (preparation → impact)</text>
+  <text x="250" y="500" text-anchor="middle" font-size="11" fill="#1e3a8a">• Emit BEST and WORST keyFrame per phase</text>
+  <text x="250" y="528" text-anchor="middle" font-size="10" font-style="italic" fill="#3b82f6">runs 100% client-side · no server compute</text>
+
+  <rect x="650" y="370" width="400" height="180" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="850" y="397" text-anchor="middle" font-size="14" font-weight="700" fill="#78350f">3B · Server · TwelveLabs Pegasus 1.2</text>
+  <text x="850" y="418" text-anchor="middle" font-size="11" fill="#475569">routes/twelvelabs.ts · services/twelvelabs.ts</text>
+  <text x="850" y="434" text-anchor="middle" font-size="11" fill="#475569">POST /v1.3/analyze (sync, direct URL)</text>
+  <text x="850" y="464" text-anchor="middle" font-size="11" fill="#78350f">• { video: { type:"url", url: r2.dev/&lt;key&gt; }, prompt }</text>
+  <text x="850" y="482" text-anchor="middle" font-size="11" fill="#78350f">• Returns text describing technique + timestamps</text>
+  <text x="850" y="500" text-anchor="middle" font-size="11" fill="#78350f">• 5–15 sec typical (vs 30–90 sec when indexed)</text>
+  <text x="850" y="528" text-anchor="middle" font-size="10" font-style="italic" fill="#d97706">collapsed index → poll → analyze into one HTTP call</text>
+
+  <!-- arrows from 3a/3b → 4 -->
+  <line x1="250" y1="550" x2="250" y2="600" stroke="#475569" stroke-width="1.5"/>
+  <line x1="850" y1="550" x2="850" y2="600" stroke="#475569" stroke-width="1.5"/>
+  <line x1="250" y1="600" x2="850" y2="600" stroke="#475569" stroke-width="1.5"/>
+  <line x1="550" y1="600" x2="550" y2="630" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="252" y="595" font-size="10" fill="#475569">poseAnalysis JSON (keyFrames + scores)</text>
+  <text x="848" y="595" text-anchor="end" font-size="10" fill="#475569">Pegasus text (free-form + timestamps)</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 4: Timeline builder                     -->
+  <!-- ============================================ -->
+  <rect x="200" y="635" width="700" height="130" rx="10" fill="#dcfce7" stroke="#10b981" stroke-width="2"/>
+  <text x="550" y="664" text-anchor="middle" font-size="14" font-weight="700" fill="#064e3b">4 · Server builds the Authoritative Timeline ⭐</text>
+  <text x="550" y="684" text-anchor="middle" font-size="11" fill="#475569">server/src/lib/timeline.ts · buildTimeline()</text>
+  <text x="550" y="708" text-anchor="middle" font-size="11" fill="#064e3b">Merge pose keyFrames (frame-accurate) + Pegasus mentions (fallback anchors)</text>
+  <text x="550" y="724" text-anchor="middle" font-size="11" fill="#064e3b">Dedupe within ±1s · pose source wins on tie</text>
+  <text x="550" y="748" text-anchor="middle" font-size="11" font-style="italic" fill="#059669">→ a single ordered list of seconds Claude is allowed to reference</text>
+
+  <!-- arrow 4 → 5 -->
+  <line x1="550" y1="765" x2="550" y2="797" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="565" y="787" font-size="10" fill="#475569">timeline.seconds[] + formatTimelineForPrompt()</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 5: Coach (Claude)                       -->
+  <!-- ============================================ -->
+  <rect x="200" y="800" width="700" height="155" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="550" y="828" text-anchor="middle" font-size="14" font-weight="700" fill="#78350f">5 · Anthropic Claude Haiku 4.5 generates feedback</text>
+  <text x="550" y="848" text-anchor="middle" font-size="11" fill="#475569">routes/coach.ts · /generateFeedback (one-shot) and /askCoach (chat)</text>
+  <text x="550" y="872" text-anchor="middle" font-size="11" fill="#78350f">• Prompt: "Reference ONLY moments from this timeline"</text>
+  <text x="550" y="890" text-anchor="middle" font-size="11" fill="#78350f">• messages.parse() with JSON-schema · Zod-validated reply</text>
+  <text x="550" y="908" text-anchor="middle" font-size="11" fill="#78350f">• Replies cite BEST and WORST exemplars per phase</text>
+  <text x="550" y="936" text-anchor="middle" font-size="10" font-style="italic" fill="#d97706">replaced Gemini after billing flake · structured output kills regex parsing</text>
+
+  <!-- arrow 5 → 6 -->
+  <line x1="550" y1="955" x2="550" y2="987" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="565" y="977" font-size="10" fill="#475569">summary, strengths, improvements, drills (with timestamps)</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 6: Snap + persist                        -->
+  <!-- ============================================ -->
+  <rect x="200" y="990" width="700" height="125" rx="10" fill="#dcfce7" stroke="#10b981" stroke-width="1.5"/>
+  <text x="550" y="1018" text-anchor="middle" font-size="14" font-weight="700" fill="#064e3b">6 · Snap timestamps → persist to Postgres</text>
+  <text x="550" y="1038" text-anchor="middle" font-size="11" fill="#475569">snapTimestampsInText() · porsager/postgres tagged-template SQL</text>
+  <text x="550" y="1062" text-anchor="middle" font-size="11" fill="#064e3b">• Every m:ss in Claude's reply → nearest authoritative second (within ±2s)</text>
+  <text x="550" y="1080" text-anchor="middle" font-size="11" fill="#064e3b">• Out-of-tolerance timestamps left untouched (caller logs)</text>
+  <text x="550" y="1098" text-anchor="middle" font-size="11" fill="#064e3b">• Stored in feedback table · message log appended for chat turns</text>
+
+  <!-- arrow 6 → 7 -->
+  <line x1="550" y1="1115" x2="550" y2="1147" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="565" y="1137" font-size="10" fill="#475569">feedback row id</text>
+
+  <!-- ============================================ -->
+  <!-- STEP 7: UI render                             -->
+  <!-- ============================================ -->
+  <rect x="200" y="1150" width="700" height="120" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="550" y="1178" text-anchor="middle" font-size="14" font-weight="700" fill="#1e3a8a">7 · Frontend renders feedback with clickable timestamp chips</text>
+  <text x="550" y="1198" text-anchor="middle" font-size="11" fill="#475569">FeedbackText (timestamps.tsx) · ChatInterface · SessionLibrary</text>
+  <text x="550" y="1222" text-anchor="middle" font-size="11" fill="#1e3a8a">• Each m:ss in feedback becomes a button that seeks the player</text>
+  <text x="550" y="1240" text-anchor="middle" font-size="11" fill="#1e3a8a">• Active session persisted in localStorage · survives reload + tab switch</text>
+  <text x="550" y="1258" text-anchor="middle" font-size="11" fill="#1e3a8a">• Coach chat continues against the same grounded timeline</text>
+
+  <!-- Footer -->
+  <text x="550" y="1300" text-anchor="middle" font-size="10" fill="#64748b">Three independent clouds (Vercel · Railway · Cloudflare) joined by URLs and env vars · No vendor lock-in for the data path</text>
+</svg>


### PR DESCRIPTION
## Summary
Full README rewrite for portfolio quality. The old README still referenced Gemini, Convex, and outdated env vars; this brings everything in line with the current stack and adds an in-depth Engineering Reflection.

## What's new
- **Top-level rewrite** — TOC, accurate stack table (Anthropic not Gemini), updated project tree (deleteSession, jobs/r2-cleanup, etc.), Quickstart with current commands, env-var reference table without obsolete keys, Scripts table for both packages, Deployment with the Railway Root Directory + `--env-file-if-exists` notes, R2 setup walkthrough including the public r2.dev hostname.
- **Architecture section** — embeds a new SVG pipeline flowchart at `docs/images/architecture-flowchart.svg` showing the 7-step path from upload to coaching feedback.
- **Engineering Reflection** — covers architecture decisions, the grounding pattern, the best-vs-worst coaching insight, the TwelveLabs API simplification, and difficulties (Convex migration, `model_options` rename, Gemini billing flake → Anthropic swap, presigned URLs vs TwelveLabs, Railway monorepo setup, the known test env-import flake). Closes with three retrospective items.
- **Image placement table** — 9 filenames with status (✅ in repo / needed / aspirational) and content notes for the portfolio version. Each `IMAGE NEEDED` placeholder is also inline in the relevant prose so the reader knows where the image belongs.

## Test plan
- [ ] Open README on GitHub — flowchart renders inline, no overlapping text, every section reads clean
- [ ] Walk through Quickstart commands — they match the current scripts (`npm run cleanup-r2` exists, `--env-file-if-exists` references hold)
- [ ] Walk through env-var table — every var listed is one the server actually reads (no GEMINI_API_KEY, ANTHROPIC_API_KEY present)
- [ ] Confirm image-placement table filenames are what you'd want to drop into `docs/images/`