### PR TITLE
feat: improve error UX across Learn, Chat, and Progress

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -12,9 +12,10 @@ interface ChatInterfaceProps {
   /** When provided, timestamp tokens (m:ss) inside assistant replies become
    *  buttons that seek the active video. */
   onSeek?: (seconds: number) => void;
+  sendError?: string | null;
 }
 
-export function ChatInterface({ messages, onSend, sport: _sport, disabled = false, presetPrompts = [], onSeek }: ChatInterfaceProps) {
+export function ChatInterface({ messages, onSend, sport: _sport, disabled = false, presetPrompts = [], onSeek, sendError }: ChatInterfaceProps) {
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -103,6 +104,9 @@ export function ChatInterface({ messages, onSend, sport: _sport, disabled = fals
               </button>
             ))}
           </div>
+        )}
+        {sendError && (
+          <p className="text-xs text-destructive mb-2">{sendError}</p>
         )}
         <form onSubmit={handleSubmit} className="flex items-center gap-2">
           <input

--- a/frontend/src/components/OvrGoal.tsx
+++ b/frontend/src/components/OvrGoal.tsx
@@ -16,6 +16,7 @@ export function OvrGoal({ userId, currentOvr }: OvrGoalProps) {
   const [deadlineInput, setDeadlineInput] = useState("");
   const [errors, setErrors] = useState<{ target?: string; deadline?: string }>({});
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // Pre-fill inputs when editing an existing goal
   useEffect(() => {
@@ -48,10 +49,13 @@ export function OvrGoal({ userId, currentOvr }: OvrGoalProps) {
       return;
     }
     setSaving(true);
+    setSaveError(null);
     try {
       await saveGoal({ userId, targetOvr: Number(targetInput), deadline: deadlineInput });
       setEditing(false);
       setErrors({});
+    } catch {
+      setSaveError("Could not save goal. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -60,6 +64,7 @@ export function OvrGoal({ userId, currentOvr }: OvrGoalProps) {
   const handleCancel = () => {
     setEditing(false);
     setErrors({});
+    setSaveError(null);
   };
 
   const daysLeft = savedGoal
@@ -129,6 +134,9 @@ export function OvrGoal({ userId, currentOvr }: OvrGoalProps) {
               {errors.deadline && <p className="mt-1 text-xs text-destructive">{errors.deadline}</p>}
             </div>
 
+            {saveError && (
+              <p className="text-xs text-destructive">{saveError}</p>
+            )}
             <div className="flex gap-2">
               <button
                 onClick={handleSave}

--- a/frontend/src/components/SessionLibrary.tsx
+++ b/frontend/src/components/SessionLibrary.tsx
@@ -12,6 +12,7 @@ interface SessionLibraryProps {
 export function SessionLibrary({ sessions, onSeek, onDelete }: SessionLibraryProps) {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set());
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   if (sessions.length === 0) {
     return (
@@ -172,21 +173,40 @@ export function SessionLibrary({ sessions, onSeek, onDelete }: SessionLibraryPro
 
                   {onDelete && (
                     <div className="pt-2 border-t border-border">
-                      <button
-                        disabled={deletingId === session.id}
-                        onClick={async () => {
-                          if (!window.confirm("Delete this session? The video file will also be removed.")) return;
-                          setDeletingId(session.id);
-                          try {
-                            await onDelete(session.id);
-                          } finally {
-                            setDeletingId(null);
-                          }
-                        }}
-                        className="text-xs text-destructive hover:underline disabled:opacity-50 disabled:no-underline"
-                      >
-                        {deletingId === session.id ? "Deleting…" : "Delete session"}
-                      </button>
+                      {confirmDeleteId === session.id ? (
+                        <div className="flex items-center gap-3">
+                          <span className="text-xs text-muted-foreground">Delete this session and its video?</span>
+                          <button
+                            disabled={deletingId === session.id}
+                            onClick={async () => {
+                              setDeletingId(session.id);
+                              setConfirmDeleteId(null);
+                              try {
+                                await onDelete(session.id);
+                              } finally {
+                                setDeletingId(null);
+                              }
+                            }}
+                            className="text-xs text-destructive font-medium hover:underline disabled:opacity-50"
+                          >
+                            {deletingId === session.id ? "Deleting…" : "Confirm"}
+                          </button>
+                          <button
+                            onClick={() => setConfirmDeleteId(null)}
+                            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          disabled={deletingId === session.id}
+                          onClick={() => setConfirmDeleteId(session.id)}
+                          className="text-xs text-destructive hover:underline disabled:opacity-50 disabled:no-underline"
+                        >
+                          Delete session
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/tabs/Learn.tsx
+++ b/frontend/src/components/tabs/Learn.tsx
@@ -6,6 +6,7 @@ import { UploadArea } from "@/components/UploadArea";
 import { ChatInterface } from "@/components/ChatInterface";
 import { VideoPlayer, VideoPlayerHandle } from "@/components/VideoPlayer";
 import { useVideoAnalysis } from "@/hooks/useVideoAnalysis";
+import { useToast } from "@/hooks/use-toast";
 
 interface LearnProps {
   sport: Sport;
@@ -16,6 +17,7 @@ export function Learn({ sport, userId }: LearnProps) {
   const askCoach = useAction(api.coach.askCoach);
   const deleteSession = useMutation(api.sessions.deleteSession);
   const videoPlayerRef = useRef<VideoPlayerHandle>(null);
+  const { toast } = useToast();
 
   const { status, error, sessionId, currentVideo, analyze, reset } = useVideoAnalysis({
     userId,
@@ -30,6 +32,7 @@ export function Learn({ sport, userId }: LearnProps) {
   // latest history session, snapping the player right back to the previous
   // video. This flag forces the upload area open until the next upload.
   const [forceUpload, setForceUpload] = useState(false);
+  const [chatError, setChatError] = useState<string | null>(null);
 
   const rawSessions = useQuery(api.sessions.listSessionsWithFeedback, { userId });
 
@@ -68,7 +71,11 @@ export function Learn({ sport, userId }: LearnProps) {
       }
     } catch (err) {
       console.error("Failed to delete session", err);
-      window.alert("Could not delete that session — try again.");
+      toast({
+        title: "Could not delete session",
+        description: "Something went wrong. Please try again.",
+        variant: "destructive",
+      });
     }
   };
 
@@ -126,10 +133,11 @@ export function Learn({ sport, userId }: LearnProps) {
 
   const handleSendMessage = async (content: string) => {
     if (!effectiveSessionId) return;
+    setChatError(null);
     try {
       await askCoach({ sessionId: effectiveSessionId, userMessage: content });
     } catch {
-      // no-op: failed reply won't appear
+      setChatError("Message failed to send. Please try again.");
     }
   };
 
@@ -179,7 +187,18 @@ export function Learn({ sport, userId }: LearnProps) {
       )}
 
       {error && (
-        <p className="text-xs text-destructive px-1">{error}</p>
+        <div className="border border-destructive/30 bg-destructive/5 rounded-lg px-4 py-3 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium text-destructive">Analysis failed</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{error}</p>
+          </div>
+          <button
+            onClick={handleSwitchVideo}
+            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors whitespace-nowrap flex-shrink-0"
+          >
+            Try again
+          </button>
+        </div>
       )}
 
       <SessionLibrary sessions={sessions} onSeek={handleSeek} onDelete={handleDeleteSession} />
@@ -191,6 +210,7 @@ export function Learn({ sport, userId }: LearnProps) {
         disabled={!effectiveSessionId}
         presetPrompts={presetPrompts}
         onSeek={handleSeek}
+        sendError={chatError}
       />
     </div>
   );


### PR DESCRIPTION
- Replace tiny red text on analysis failure with an inline error card + "Try again" button
- Surface chat send failures inline in ChatInterface instead of swallowing them
- Replace window.alert() on session delete error with a destructive toast
- Replace window.confirm() on delete with inline Confirm/Cancel buttons in SessionLibrary
- Catch OvrGoal save failures and display an inline error message